### PR TITLE
feat(search): add plugin search and case-insensitive site matching

### DIFF
--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -2,7 +2,9 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 
+	"github.com/JCO-Digital/jman/internal/cache"
 	"github.com/JCO-Digital/jman/internal/search"
 	"github.com/JCO-Digital/jman/internal/verbosity"
 	"github.com/spf13/cobra"
@@ -15,19 +17,57 @@ var searchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		query := args[0]
 
-		sites, err := search.SearchSites(query)
+		matchedSites, err := search.SearchSites(query)
 		if err != nil {
 			return fmt.Errorf("error searching sites: %w", err)
 		}
 
-		if len(sites) == 0 {
-			verbosity.Printf(verbosity.Verbose, "No sites found matching '%s'.\n", query)
+		matchedPlugins, err := search.SearchPlugins(query)
+		if err != nil {
+			return fmt.Errorf("error searching plugins: %w", err)
+		}
+
+		if len(matchedSites) == 0 && len(matchedPlugins) == 0 {
+			verbosity.Printf(verbosity.Normal, "No sites or plugins found matching '%s'.\n", query)
 			return nil
 		}
 
-		verbosity.Printf(verbosity.Normal, "Found %d sites matching '%s':\n", len(sites), query)
-		for _, site := range sites {
-			verbosity.Printf(verbosity.Quiet, "- %s (Server: %s)\n", site.Name, site.ServerName)
+		if len(matchedSites) > 0 {
+			verbosity.Printf(verbosity.Normal, "Found %d sites matching '%s':\n", len(matchedSites), query)
+			for _, site := range matchedSites {
+				verbosity.Printf(verbosity.Quiet, "- %s (Server: %s)\n", site.Name, site.ServerName)
+			}
+			if len(matchedPlugins) > 0 {
+				fmt.Println()
+			}
+		}
+
+		if len(matchedPlugins) > 0 {
+			allSites, err := cache.GetSiteList()
+			if err != nil {
+				return fmt.Errorf("error getting site list: %w", err)
+			}
+			siteMap := make(map[int]string)
+			for _, s := range allSites {
+				siteMap[s.ID] = s.Name
+			}
+
+			verbosity.Printf(verbosity.Normal, "Found %d plugins matching '%s':\n", len(matchedPlugins), query)
+			for _, plugin := range matchedPlugins {
+				verbosity.Printf(verbosity.Quiet, "- %s\n", plugin.Name)
+
+				sort.Slice(plugin.Sites, func(i, j int) bool {
+					return siteMap[plugin.Sites[i].SiteID] < siteMap[plugin.Sites[j].SiteID]
+				})
+
+				for _, site := range plugin.Sites {
+					siteName := siteMap[site.SiteID]
+					if siteName == "" {
+						siteName = fmt.Sprintf("Unknown Site (ID: %d)", site.SiteID)
+					}
+					verbosity.Printf(verbosity.Quiet, "  * %s (%s)\n", siteName, site.Version)
+				}
+			}
 		}
 
 		return nil

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/JCO-Digital/jman/internal/cache"
@@ -19,11 +20,52 @@ func SearchSites(query string) ([]models.CliSite, error) {
 	}
 
 	var matched []models.CliSite
+	query = strings.ToLower(query)
 	for _, site := range sites {
-		if strings.Contains(site.Name, query) || strings.Contains(site.ServerName, query) {
+		if strings.Contains(strings.ToLower(site.Name), query) || strings.Contains(strings.ToLower(site.ServerName), query) {
 			matched = append(matched, site)
 		}
 	}
+
+	return matched, nil
+}
+
+// SearchPlugins filters the plugin list based on the provided query string
+func SearchPlugins(query string) ([]models.WPPluginData, error) {
+	plugins, err := cache.GetCachedPlugins(false)
+	if err != nil {
+		return nil, err
+	}
+
+	pluginMap := make(map[string]*models.WPPluginData)
+	query = strings.ToLower(query)
+
+	for _, p := range plugins {
+		if strings.Contains(strings.ToLower(p.Name), query) {
+			data, exists := pluginMap[p.Name]
+			if !exists {
+				newData := &models.WPPluginData{
+					Name:  p.Name,
+					Sites: []models.PluginSite{},
+				}
+				pluginMap[p.Name] = newData
+				data = newData
+			}
+			data.Sites = append(data.Sites, models.PluginSite{
+				SiteID:  p.SiteID,
+				Version: p.Version,
+			})
+		}
+	}
+
+	var matched []models.WPPluginData
+	for _, data := range pluginMap {
+		matched = append(matched, *data)
+	}
+
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].Name < matched[j].Name
+	})
 
 	return matched, nil
 }


### PR DESCRIPTION
Plugin results display the name, site, and version for each match. Site ID mapping is used to show
site names instead of IDs. Results are sorted alphabetically for better readability.