### PR TITLE
Feat/core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build dev prepare install clean test format
 
 # Go build flags
-LDFLAGS := -s -w -X main.Version=$(shell git describe --tags --always --dirty || echo "dev")
+LDFLAGS := -s -w -X github.com/JCO-Digital/jman/internal/config.AppVersion=$(shell git describe --tags --always --dirty || echo "dev")
 
 build: clean prepare bin/jman bin/jman-api bin/jman-monitor
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ build: clean prepare bin/jman bin/jman-api bin/jman-monitor
 bin/jman:
 	go build -ldflags="$(LDFLAGS)" -o bin/jman ./cmd/jman
 
+bin/jman.exe:
+	GOOS=windows go build -ldflags="$(LDFLAGS)" -o bin/jman.exe ./cmd/jman
+
 bin/jman-api:
 	go build -ldflags="$(LDFLAGS)" -o bin/jman-api ./cmd/jman-api
 

--- a/cmd/jman-api/main.go
+++ b/cmd/jman-api/main.go
@@ -10,11 +10,8 @@ import (
 	"github.com/JCO-Digital/jman/internal/config"
 )
 
-// Version is injected by the build flags
-var Version = "dev"
-
 func main() {
-	if err := config.Init(Version); err != nil {
+	if err := config.Init(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
 		os.Exit(1)
 	}
@@ -27,7 +24,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// Register API routes from the internal/api package
-	api.RegisterHandlers(mux, Version)
+	api.RegisterHandlers(mux, config.AppVersion)
 
 	// Wrap mux with middleware
 	handler := api.LoggingMiddleware(
@@ -36,7 +33,7 @@ func main() {
 		),
 	)
 
-	log.Printf("Starting jman-api (version: %s) on :%s", Version, port)
+	log.Printf("Starting jman-api (version: %s) on :%s", config.AppVersion, port)
 	if err := http.ListenAndServe(":"+port, handler); err != nil {
 		log.Fatalf("Server failed to start: %v", err)
 	}

--- a/cmd/jman-monitor/main.go
+++ b/cmd/jman-monitor/main.go
@@ -10,9 +10,6 @@ import (
 	"github.com/JCO-Digital/jman/internal/verbosity"
 )
 
-// Version is injected by the build flags
-var Version = "dev"
-
 var (
 	flagVerbose bool
 	flagDebug   bool
@@ -36,7 +33,7 @@ func main() {
 	}
 
 	// Initialize config
-	if err := config.Init(Version); err != nil {
+	if err := config.Init(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/jman/main.go
+++ b/cmd/jman/main.go
@@ -8,11 +8,8 @@ import (
 	"github.com/JCO-Digital/jman/internal/config"
 )
 
-// Version is injected by the build flags
-var Version = "dev"
-
 func main() {
-	if err := config.Init(Version); err != nil {
+	if err := config.Init(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/commands/core.go
+++ b/internal/commands/core.go
@@ -44,13 +44,20 @@ func coreCommand(cmd *cobra.Command, args []string) error {
 		updated := 0
 		for _, site := range sites {
 			verbosity.Printf(verbosity.Verbose, "Checking WordPress core on %s...\n", site.Name)
-			hasUpdate, err := wpcli.CheckCore(site.SSH, site.Path)
+			coreUpdates, err := wpcli.CheckCore(site.SSH, site.Path)
 			if err != nil {
 				verbosity.PrintErrorf(verbosity.Normal, "Error checking core on %s: %v\n", site.Name, err)
 				continue
 			}
-			if hasUpdate {
-				verbosity.Printf(verbosity.Normal, "Update available for %s.\n", site.Name)
+			if len(coreUpdates) > 0 {
+				currentVersion, err := wpcli.CoreVersion(site.SSH, site.Path)
+				if err != nil {
+					verbosity.PrintErrorf(verbosity.Normal, "Error getting current core version on %s: %v\n", site.Name, err)
+					continue
+				}
+				for _, update := range coreUpdates {
+					verbosity.Printf(verbosity.Normal, "Update available for %s: %s -> %s (%s)\n", site.Name, currentVersion, update.Version, update.UpdateType)
+				}
 				updates++
 			} else {
 				verbosity.Printf(verbosity.Verbose, "WordPress core is up to date on %s.\n", site.Name)

--- a/internal/commands/core.go
+++ b/internal/commands/core.go
@@ -38,26 +38,57 @@ func coreCommand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	for _, site := range sites {
-		switch operation {
-		case "check":
-			err := wpcli.CheckCore(site.SSH, site.Path)
+	switch operation {
+	case "check":
+		updates := 0
+		updated := 0
+		for _, site := range sites {
+			verbosity.Printf(verbosity.Verbose, "Checking WordPress core on %s...\n", site.Name)
+			hasUpdate, err := wpcli.CheckCore(site.SSH, site.Path)
 			if err != nil {
 				verbosity.PrintErrorf(verbosity.Normal, "Error checking core on %s: %v\n", site.Name, err)
 				continue
 			}
-		case "update":
-			updateErr := wpcli.UpdateCore(site.SSH, site.Path)
-			if updateErr != nil {
-				verbosity.PrintErrorf(verbosity.Normal, "Error updating core on %s: %v\n", site.Name, updateErr)
+			if hasUpdate {
+				verbosity.Printf(verbosity.Normal, "Update available for %s.\n", site.Name)
+				updates++
+			} else {
+				verbosity.Printf(verbosity.Verbose, "WordPress core is up to date on %s.\n", site.Name)
+				updated++
+			}
+		}
+		if updated > 0 {
+			verbosity.Printf(verbosity.Normal, "%d site(s) are up to date.\n", updated)
+		}
+		if updates > 0 {
+			verbosity.Printf(verbosity.Normal, "%d site(s) have updates available.\n", updates)
+		}
+	case "update":
+		updated := 0
+		for _, site := range sites {
+			verbosity.Printf(verbosity.Verbose, "Updating WordPress core on %s...\n", site.Name)
+			success, err := wpcli.UpdateCore(site.SSH, site.Path)
+			if err != nil {
+				verbosity.PrintErrorf(verbosity.Normal, "Error updating core on %s: %v\n", site.Name, err)
 				continue
 			}
-		case "version":
-			err := wpcli.ShowCoreVersion(site.SSH, site.Path)
+			if success {
+				verbosity.Printf(verbosity.Normal, "Successfully updated WordPress core on %s.\n", site.Name)
+				updated++
+			}
+		}
+		if updated > 0 {
+			verbosity.Printf(verbosity.Normal, "Successfully updated core on %d site(s).\n", updated)
+		}
+	case "version":
+		for _, site := range sites {
+			verbosity.Printf(verbosity.Verbose, "Showing WordPress core version on %s...\n", site.Name)
+			version, err := wpcli.CoreVersion(site.SSH, site.Path)
 			if err != nil {
 				verbosity.PrintErrorf(verbosity.Normal, "Error showing core version on %s: %v\n", site.Name, err)
 				continue
 			}
+			verbosity.Printf(verbosity.Normal, "WordPress core version on %s: %s\n", site.Name, version)
 		}
 	}
 

--- a/internal/commands/core.go
+++ b/internal/commands/core.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/JCO-Digital/jman/internal/search"
+	"github.com/JCO-Digital/jman/internal/verbosity"
+	"github.com/JCO-Digital/jman/internal/wpcli"
+	"github.com/spf13/cobra"
+)
+
+var coreCmd = &cobra.Command{
+	Use:   "core <target> [check|update|version]",
+	Short: "Manage WordPress core.",
+	Long:  "Check core version, update core to latest version, or display current core version on target sites.",
+	Args:  cobra.MinimumNArgs(2),
+	RunE:  coreCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(coreCmd)
+}
+
+func coreCommand(cmd *cobra.Command, args []string) error {
+	target := args[0]
+	operation := args[1]
+	if operation != "check" && operation != "update" && operation != "version" {
+		return fmt.Errorf("invalid operation: %s. Use 'check', 'update', or 'version'", operation)
+	}
+
+	sites, err := search.PromptSearch(target)
+	if err != nil {
+		return err
+	}
+
+	if len(sites) == 0 {
+		fmt.Println("Operation cancelled or no sites matched.")
+		return nil
+	}
+
+	for _, site := range sites {
+		switch operation {
+		case "check":
+			err := wpcli.CheckCore(site.SSH, site.Path)
+			if err != nil {
+				verbosity.PrintErrorf(verbosity.Normal, "Error checking core on %s: %v\n", site.Name, err)
+				continue
+			}
+		case "update":
+			updateErr := wpcli.UpdateCore(site.SSH, site.Path)
+			if updateErr != nil {
+				verbosity.PrintErrorf(verbosity.Normal, "Error updating core on %s: %v\n", site.Name, updateErr)
+				continue
+			}
+		case "version":
+			err := wpcli.ShowCoreVersion(site.SSH, site.Path)
+			if err != nil {
+				verbosity.PrintErrorf(verbosity.Normal, "Error showing core version on %s: %v\n", site.Name, err)
+				continue
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/commands/core.go
+++ b/internal/commands/core.go
@@ -34,7 +34,7 @@ func coreCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(sites) == 0 {
-		fmt.Println("Operation cancelled or no sites matched.")
+		verbosity.Println(verbosity.Normal, "Operation cancelled or no sites matched.")
 		return nil
 	}
 

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/JCO-Digital/jman/internal/models"
 	"github.com/JCO-Digital/jman/internal/search"
@@ -13,8 +12,8 @@ import (
 
 var pluginCmd = &cobra.Command{
 	Use:   "plugin <target> [list|install|update|remove] <plugin-name>",
-	Short: "Install a plugin on target sites.",
-	Long:  "Install a plugin on target sites. Supports WordPress.org slugs or custom repo URLs.",
+	Short: "Plugin actions on target sites.",
+	Long:  "List, install, update or remove plugins on target sites. Supports WordPress.org slugs or custom repo URLs.",
 	Args:  cobra.MinimumNArgs(2),
 	RunE:  pluginCommand,
 }
@@ -157,9 +156,7 @@ func updatePlugin(site models.CliSite, pluginName string) error {
 	}
 	verbosity.Printf(verbosity.Normal, "Updating %d plugins on %s...\n", len(toUpdate), site.Name)
 
-	pluginList := strings.Join(toUpdate, " ")
-
-	updated, err := wpcli.UpdatePlugin(site.SSH, site.Path, pluginList)
+	updated, err := wpcli.UpdatePlugin(site.SSH, site.Path, toUpdate)
 
 	verbosity.Printf(verbosity.Verbose, "Updated %d plugins on %s.\n", updated, site.Name)
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -10,7 +10,6 @@ var (
 	flagQuiet   bool
 	flagVerbose bool
 	flagDebug   bool
-	flagVersion bool
 )
 
 var rootCmd = &cobra.Command{
@@ -18,17 +17,7 @@ var rootCmd = &cobra.Command{
 	Short: "A CLI tool for managing WordPress projects",
 	Long:  `jman is a command-line utility designed to manage WordPress sites hosted on SpinupWP.`,
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		// If no subcommand is provided, show the help message
-		if !flagVersion {
-			cmd.Help()
-		}
-	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if flagVersion {
-			verbosity.PrintErrorf(verbosity.Quiet, "jman version %s\n", config.RunData.Version)
-			return nil
-		}
 
 		switch {
 		case flagDebug:
@@ -56,10 +45,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&flagQuiet, "quiet", "q", false, "suppress all non-essential output")
 	rootCmd.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "enable additional informational output")
 	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "d", false, "enable detailed debug output")
-
-	rootCmd.PersistentFlags().BoolVar(&flagVersion, "version", false, "show version information")
-
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose", "debug")
+
+	rootCmd.Version = config.AppVersion
 
 	// Hide the default completion command
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -10,13 +10,26 @@ var (
 	flagQuiet   bool
 	flagVerbose bool
 	flagDebug   bool
+	flagVersion bool
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "jman",
 	Short: "A CLI tool for managing WordPress projects",
 	Long:  `jman is a command-line utility designed to manage WordPress sites hosted on SpinupWP.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		// If no subcommand is provided, show the help message
+		if !flagVersion {
+			cmd.Help()
+		}
+	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if flagVersion {
+			verbosity.PrintErrorf(verbosity.Quiet, "jman version %s\n", config.RunData.Version)
+			return nil
+		}
+
 		switch {
 		case flagDebug:
 			verbosity.Set(verbosity.Debug)
@@ -28,8 +41,9 @@ var rootCmd = &cobra.Command{
 			verbosity.Set(verbosity.Normal)
 		}
 
-		verbosity.PrintErrorf(verbosity.Normal, "Version: %s\n", config.RunData.Version)
+		verbosity.PrintErrorf(verbosity.Verbose, "Version: %s\n", config.RunData.Version)
 		verbosity.PrintErrorf(verbosity.Debug, "Verbosity: %s\n", verbosity.Get())
+		return nil
 	},
 }
 
@@ -42,6 +56,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&flagQuiet, "quiet", "q", false, "suppress all non-essential output")
 	rootCmd.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "enable additional informational output")
 	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "d", false, "enable detailed debug output")
+
+	rootCmd.PersistentFlags().BoolVar(&flagVersion, "version", false, "show version information")
 
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose", "debug")
 

--- a/internal/commands/wp.go
+++ b/internal/commands/wp.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/JCO-Digital/jman/internal/search"
 	"github.com/JCO-Digital/jman/internal/verbosity"
@@ -16,7 +15,6 @@ var wpCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
-		wpArgs := strings.Join(args[1:], " ")
 
 		sites, err := search.PromptSearch(target)
 		if err != nil {
@@ -30,7 +28,7 @@ var wpCmd = &cobra.Command{
 
 		for _, site := range sites {
 			verbosity.Printf(verbosity.Verbose, "\n=== %s (%s) ===\n", site.Name, site.ServerName)
-			res, err := wpcli.RunWP(site.SSH, site.Path, wpArgs, false)
+			res, err := wpcli.RunWP(site.SSH, site.Path, false, args[1:]...)
 
 			if res.Output != "" {
 				verbosity.Println(verbosity.Quiet, res.Output)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 
 const AppName = "jman"
 
+var AppVersion = "dev"
+
 // Runtime holds the dynamic paths and version information for the application.
 type Runtime struct {
 	ConfigDir string
@@ -39,12 +41,11 @@ var (
 )
 
 // Init sets up the application runtime directories and loads the configuration.
-func Init(version string) error {
+func Init() error {
 	RunData = Runtime{
 		ConfigDir: filepath.Join(xdg.ConfigHome, AppName),
 		CacheDir:  filepath.Join(xdg.CacheHome, AppName),
 		DataDir:   filepath.Join(xdg.DataHome, AppName),
-		Version:   version,
 	}
 
 	// Ensure directories exist

--- a/internal/wpcli/core.go
+++ b/internal/wpcli/core.go
@@ -1,6 +1,7 @@
 package wpcli
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -8,19 +9,31 @@ import (
 	"github.com/JCO-Digital/jman/internal/verbosity"
 )
 
-// Check WordPress core for updates and display the current version and available updates if any.
-func CheckCore(ssh, path string) (bool, error) {
-	res, err := RunWP(ssh, path, true, "core", "check-update")
+// CoreUpdate represents a WordPress core update notification from wp-cli.
+type CoreUpdate struct {
+	Version    string `json:"version"`
+	UpdateType string `json:"update_type"`
+	PackageURL string `json:"package_url"`
+}
+
+// Check WordPress core for updates and return the available updates if any.
+func CheckCore(ssh, path string) ([]CoreUpdate, error) {
+	res, err := RunWP(ssh, path, true, "core", "check-update", "--format=json")
 	if err != nil {
-		return false, fmt.Errorf("failed to check core updates: %w (stderr: %s)", err, res.Error)
-	}
-	if strings.TrimSpace(res.Output) == "Success: WordPress is at the latest version." {
-		verbosity.Println(verbosity.Verbose, "WordPress core is up to date.")
-		return false, nil
+		return nil, fmt.Errorf("failed to check core updates: %w (stderr: %s)", err, res.Error)
 	}
 
-	verbosity.Print(verbosity.Normal, res.Output)
-	return true, nil
+	output := strings.TrimSpace(res.Output)
+	if output == "" || output == "[]" {
+		return nil, nil
+	}
+
+	var updates []CoreUpdate
+	if err := json.Unmarshal([]byte(output), &updates); err != nil {
+		return nil, fmt.Errorf("failed to parse core update JSON: %w", err)
+	}
+
+	return updates, nil
 }
 
 var updateRegex = regexp.MustCompile(`^Updating to version [0-9.-]+ \([^)]+\)...`)

--- a/internal/wpcli/core.go
+++ b/internal/wpcli/core.go
@@ -1,0 +1,51 @@
+package wpcli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Check WordPress core for updates and display the current version and available updates if any.
+func CheckCore(ssh, path string) error {
+	res, err := RunWP(ssh, path, true, "core", "version")
+	if err != nil {
+		return fmt.Errorf("failed to get core version: %w (stderr: %s)", err, res.Error)
+	}
+	fmt.Printf("Current version: %s", res.Output)
+
+	res, err = RunWP(ssh, path, true, "core", "check-update")
+	if err != nil {
+		return fmt.Errorf("failed to check core updates: %w (stderr: %s)", err, res.Error)
+	}
+	fmt.Print(res.Output)
+	return nil
+}
+
+// Update WordPress core to the latest minor version. This will also update the database if necessary.
+func UpdateCore(ssh, path string) error {
+	fmt.Println("Updating WordPress core...")
+	res, err := RunWP(ssh, path, true, "core", "update", "--minor")
+	if err != nil {
+		return fmt.Errorf("failed to update core: %w (stderr: %s)", err, res.Error)
+	}
+	fmt.Print(res.Output)
+
+	fmt.Println("Checking for database updates...")
+	res, err = RunWP(ssh, path, true, "core", "update-db")
+	if err != nil {
+		return fmt.Errorf("failed to update core database: %w (stderr: %s)", err, res.Error)
+	}
+	fmt.Print(res.Output)
+
+	return nil
+}
+
+// ShowCoreVersion displays the current WordPress core version on the target site.
+func ShowCoreVersion(ssh, path string) error {
+	res, err := RunWP(ssh, path, true, "core", "version")
+	if err != nil {
+		return fmt.Errorf("failed to show core version: %w (stderr: %s)", err, res.Error)
+	}
+	fmt.Printf("WordPress version: %s", strings.TrimSpace(res.Output))
+	return nil
+}

--- a/internal/wpcli/core.go
+++ b/internal/wpcli/core.go
@@ -36,7 +36,7 @@ func CheckCore(ssh, path string) ([]CoreUpdate, error) {
 	return updates, nil
 }
 
-var updateRegex = regexp.MustCompile(`^Updating to version [0-9.-]+ \([^)]+\)...`)
+var updateRegex = regexp.MustCompile(`(?m)^Updating to version [0-9.-]+ \([^)]+\)...`)
 
 // Update WordPress core to the latest minor version. This will also update the database if necessary.
 func UpdateCore(ssh, path string) (bool, error) {

--- a/internal/wpcli/core.go
+++ b/internal/wpcli/core.go
@@ -2,50 +2,65 @@ package wpcli
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
+
+	"github.com/JCO-Digital/jman/internal/verbosity"
 )
 
 // Check WordPress core for updates and display the current version and available updates if any.
-func CheckCore(ssh, path string) error {
-	res, err := RunWP(ssh, path, true, "core", "version")
+func CheckCore(ssh, path string) (bool, error) {
+	res, err := RunWP(ssh, path, true, "core", "check-update")
 	if err != nil {
-		return fmt.Errorf("failed to get core version: %w (stderr: %s)", err, res.Error)
+		return false, fmt.Errorf("failed to check core updates: %w (stderr: %s)", err, res.Error)
 	}
-	fmt.Printf("Current version: %s", res.Output)
+	if strings.TrimSpace(res.Output) == "Success: WordPress is at the latest version." {
+		verbosity.Println(verbosity.Verbose, "WordPress core is up to date.")
+		return false, nil
+	}
 
-	res, err = RunWP(ssh, path, true, "core", "check-update")
-	if err != nil {
-		return fmt.Errorf("failed to check core updates: %w (stderr: %s)", err, res.Error)
-	}
-	fmt.Print(res.Output)
-	return nil
+	verbosity.Print(verbosity.Normal, res.Output)
+	return true, nil
 }
+
+var updateRegex = regexp.MustCompile(`^Updating to version [0-9.-]+ \([^)]+\)...`)
 
 // Update WordPress core to the latest minor version. This will also update the database if necessary.
-func UpdateCore(ssh, path string) error {
-	fmt.Println("Updating WordPress core...")
+func UpdateCore(ssh, path string) (bool, error) {
 	res, err := RunWP(ssh, path, true, "core", "update", "--minor")
 	if err != nil {
-		return fmt.Errorf("failed to update core: %w (stderr: %s)", err, res.Error)
+		return false, fmt.Errorf("failed to update core: %w (stderr: %s)", err, res.Error)
 	}
-	fmt.Print(res.Output)
 
-	fmt.Println("Checking for database updates...")
+	// return early if already up to date to avoid printing unnecessary output
+	if strings.Contains(res.Output, "Success: WordPress is at the latest") {
+		return false, nil
+	}
+
+	verbosity.Print(verbosity.Debug, res.Output)
+
+	updateLines := updateRegex.FindString(res.Output)
+	if updateLines != "" {
+		verbosity.Println(verbosity.Normal, updateLines)
+	}
+	if !strings.Contains(res.Output, "Success: WordPress updated successfully.") {
+		return false, fmt.Errorf("core update did not complete successfully (stderr: %s)", res.Error)
+	}
+
 	res, err = RunWP(ssh, path, true, "core", "update-db")
 	if err != nil {
-		return fmt.Errorf("failed to update core database: %w (stderr: %s)", err, res.Error)
+		return false, fmt.Errorf("failed to update core database: %w (stderr: %s)", err, res.Error)
 	}
 	fmt.Print(res.Output)
 
-	return nil
+	return true, nil
 }
 
-// ShowCoreVersion displays the current WordPress core version on the target site.
-func ShowCoreVersion(ssh, path string) error {
+// CoreVersion returns the current WordPress core version on the target site.
+func CoreVersion(ssh, path string) (string, error) {
 	res, err := RunWP(ssh, path, true, "core", "version")
 	if err != nil {
-		return fmt.Errorf("failed to show core version: %w (stderr: %s)", err, res.Error)
+		return "", fmt.Errorf("failed to show core version: %w (stderr: %s)", err, res.Error)
 	}
-	fmt.Printf("WordPress version: %s", strings.TrimSpace(res.Output))
-	return nil
+	return strings.TrimSpace(res.Output), nil
 }

--- a/internal/wpcli/core.go
+++ b/internal/wpcli/core.go
@@ -64,7 +64,7 @@ func UpdateCore(ssh, path string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to update core database: %w (stderr: %s)", err, res.Error)
 	}
-	fmt.Print(res.Output)
+	verbosity.Print(verbosity.Verbose, res.Output)
 
 	return true, nil
 }

--- a/internal/wpcli/plugins.go
+++ b/internal/wpcli/plugins.go
@@ -12,7 +12,7 @@ import (
 
 // GetPlugins returns a list of installed plugins on the target site.
 func GetPlugins(site models.CliSite) ([]models.WPPlugin, error) {
-	res, err := RunWP(site.SSH, site.Path, "plugin list --format=json", true)
+	res, err := RunWP(site.SSH, site.Path, true, "plugin", "list", "--format=json")
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return nil, fmt.Errorf("not a WordPress site")
@@ -58,12 +58,11 @@ func GetPlugins(site models.CliSite) ([]models.WPPlugin, error) {
 
 // AddPlugin installs and optionally activates a plugin.
 func AddPlugin(ssh, path, plugin string, activate bool) (bool, error) {
-	activateFlag := ""
+	args := []string{"plugin", "install", plugin}
 	if activate {
-		activateFlag = "--activate"
+		args = append(args, "--activate")
 	}
-	cmd := fmt.Sprintf("plugin install %s %s", plugin, activateFlag)
-	res, err := RunWP(ssh, path, cmd, true)
+	res, err := RunWP(ssh, path, true, args...)
 	if err != nil {
 		if strings.Contains(res.Error, "Plugin not found.") {
 			return false, fmt.Errorf("plugin not found")
@@ -82,9 +81,17 @@ type UpdateResult struct {
 	Status     string `json:"status"`
 }
 
-func UpdatePlugin(ssh, path, pluginList string) (int, error) {
-	cmd := fmt.Sprintf("plugin update %s --format=json", pluginList)
-	res, err := RunWP(ssh, path, cmd, true)
+// UpdatePlugin updates one or more plugins.
+func UpdatePlugin(ssh, path string, plugins []string) (int, error) {
+	if len(plugins) == 0 {
+		return 0, nil
+	}
+
+	args := []string{"plugin", "update"}
+	args = append(args, plugins...)
+	args = append(args, "--format=json")
+
+	res, err := RunWP(ssh, path, true, args...)
 	if err != nil {
 		return 0, fmt.Errorf("failed to update plugin: %w (stderr: %s)", err, res.Error)
 	}
@@ -104,9 +111,9 @@ func UpdatePlugin(ssh, path, pluginList string) (int, error) {
 	return updated, nil
 }
 
+// RemovePlugin uninstalls and deactivates a plugin.
 func RemovePlugin(ssh, path, plugin string) (bool, error) {
-	cmd := fmt.Sprintf("plugin uninstall %s --deactivate", plugin)
-	res, err := RunWP(ssh, path, cmd, true)
+	res, err := RunWP(ssh, path, true, "plugin", "uninstall", plugin, "--deactivate")
 	if err != nil {
 		return false, fmt.Errorf("failed to remove plugin: %w (stderr: %s)", err, res.Error)
 	}

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -12,35 +12,56 @@ type RunResult struct {
 	Error  string
 }
 
-// RunWP executes a wp-cli command via SSH.
-func RunWP(ssh, path, command string, skip bool) (RunResult, error) {
+// RunWP executes a wp-cli command. If ssh is provided, it runs via SSH.
+// It uses variadic arguments to avoid shell injection and quoting issues.
+func RunWP(ssh, path string, skip bool, args ...string) (RunResult, error) {
 	if _, err := exec.LookPath("wp"); err != nil {
 		return RunResult{}, fmt.Errorf("wp-cli executable not found in PATH")
 	}
 
-	skipArgs := ""
-	if skip {
-		skipArgs = "--skip-plugins --skip-themes "
+	var fullArgs []string
+	if ssh != "" {
+		fullArgs = append(fullArgs, fmt.Sprintf("--ssh=%s", ssh))
+	}
+	if path != "" {
+		fullArgs = append(fullArgs, fmt.Sprintf("--path=%s", path))
 	}
 
-	fullCmd := fmt.Sprintf("wp --ssh=%s --path=%s %s %s", ssh, path, skipArgs, command)
-	cmd := exec.Command("sh", "-c", fullCmd)
+	if skip {
+		fullArgs = append(fullArgs, "--skip-plugins", "--skip-themes")
+	}
+
+	fullArgs = append(fullArgs, args...)
+
+	cmd := exec.Command("wp", fullArgs...)
 
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
 
 	err := cmd.Run()
-	return RunResult{
+	res := RunResult{
 		Output: outBuf.String(),
 		Error:  errBuf.String(),
-	}, err
+	}
+
+	// If cmd.Run() returned an error (non-zero exit code), we return it.
+	if err != nil {
+		return res, err
+	}
+
+	// wp-cli sometimes exits with 0 even on certain failures (like connection errors),
+	// so we check stderr for the "Error:" prefix to detect these cases.
+	if strings.Contains(res.Error, "Error:") {
+		return res, fmt.Errorf("wp-cli error: %s", strings.TrimSpace(res.Error))
+	}
+
+	return res, nil
 }
 
 // AddUser creates a new user on the target WordPress site.
 func AddUser(ssh, path, username, email, role string) (string, error) {
-	cmd := fmt.Sprintf("user create %s %s --role=%s", username, email, role)
-	res, err := RunWP(ssh, path, cmd, true)
+	res, err := RunWP(ssh, path, true, "user", "create", username, email, "--role="+role)
 	if err != nil {
 		return "", fmt.Errorf("failed to add user: %w (stderr: %s)", err, res.Error)
 	}
@@ -56,8 +77,7 @@ func AddUser(ssh, path, username, email, role string) (string, error) {
 
 // ResetUserPassword resets the password for a given user.
 func ResetUserPassword(ssh, path, username string) (string, error) {
-	cmd := fmt.Sprintf("user reset-password %s --porcelain", username)
-	res, err := RunWP(ssh, path, cmd, true)
+	res, err := RunWP(ssh, path, true, "user", "reset-password", username, "--porcelain")
 	if err != nil {
 		return "", fmt.Errorf("failed to reset password: %w (stderr: %s)", err, res.Error)
 	}
@@ -70,7 +90,6 @@ func SetDisallowFileMods(ssh, path string, value bool) error {
 	if value {
 		valStr = "true"
 	}
-	cmd := fmt.Sprintf("config set --raw DISALLOW_FILE_MODS %s", valStr)
-	_, err := RunWP(ssh, path, cmd, true)
+	_, err := RunWP(ssh, path, true, "config", "set", "--raw", "DISALLOW_FILE_MODS", valStr)
 	return err
 }

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -51,9 +51,19 @@ func RunWP(ssh, path string, skip bool, args ...string) (RunResult, error) {
 	}
 
 	// wp-cli sometimes exits with 0 even on certain failures (like connection errors),
-	// so we check stderr for the "Error:" prefix to detect these cases.
-	if strings.Contains(res.Error, "Error:") {
-		return res, fmt.Errorf("wp-cli error: %s", strings.TrimSpace(res.Error))
+	// so we check the first non-empty stderr line for the "Error:" prefix to detect these cases.
+	if res.Error != "" {
+		for _, line := range strings.Split(res.Error, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if strings.HasPrefix(trimmed, "Error:") {
+				return res, fmt.Errorf("wp-cli error: %s", trimmed)
+			}
+			// Only consider the first non-empty line.
+			break
+		}
 	}
 
 	return res, nil

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -53,7 +53,7 @@ func RunWP(ssh, path string, skip bool, args ...string) (RunResult, error) {
 	// wp-cli sometimes exits with 0 even on certain failures (like connection errors),
 	// so we check the first non-empty stderr line for the "Error:" prefix to detect these cases.
 	if res.Error != "" {
-		for _, line := range strings.Split(res.Error, "\n") {
+		for line := range strings.SplitSeq(res.Error, "\n") {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" {
 				continue


### PR DESCRIPTION
This pull request introduces a new command for WordPress core management, refactors the way wp-cli commands are executed throughout the codebase for improved safety and flexibility, and adds a version flag to the CLI. The most significant changes are the addition of the `core` command, a comprehensive refactor of plugin and wp-cli command handling, and improvements to user experience and command reliability.

**New WordPress core management features:**

* Added a new `core` subcommand (`internal/commands/core.go`) that allows users to check, update, and display WordPress core versions across target sites. This includes robust error handling and clear output for each operation.
* Implemented supporting functions for core management (`CheckCore`, `UpdateCore`, `CoreVersion`) in `internal/wpcli/core.go`. These provide structured update checks, safe updates, and version retrieval.

**Refactoring wp-cli command execution:**

* Refactored the `RunWP` function in `internal/wpcli/wpcli.go` to use variadic arguments instead of shell command strings, reducing the risk of shell injection and improving argument handling. All usages across the codebase have been updated to this safer approach. [[1]](diffhunk://#diff-9f6b5a921ec2474091809be7b8a4f0e809783ebb6ee3f44a2a38b2146241a5d1L15-R64) [[2]](diffhunk://#diff-9f6b5a921ec2474091809be7b8a4f0e809783ebb6ee3f44a2a38b2146241a5d1L59-R80) [[3]](diffhunk://#diff-9f6b5a921ec2474091809be7b8a4f0e809783ebb6ee3f44a2a38b2146241a5d1L73-R93) [[4]](diffhunk://#diff-f9f25f5994c8026d7668e95920efe391e30685a7e3159b96844a8121daaada6dL15-R15) [[5]](diffhunk://#diff-f9f25f5994c8026d7668e95920efe391e30685a7e3159b96844a8121daaada6dL61-R65) [[6]](diffhunk://#diff-f9f25f5994c8026d7668e95920efe391e30685a7e3159b96844a8121daaada6dL85-R94) [[7]](diffhunk://#diff-f9f25f5994c8026d7668e95920efe391e30685a7e3159b96844a8121daaada6dR114-R116) [[8]](diffhunk://#diff-50aa11804f5954befb45c10f84bd39d6c706614abf6cf7ba891b35cc936f4bcbL5) [[9]](diffhunk://#diff-50aa11804f5954befb45c10f84bd39d6c706614abf6cf7ba891b35cc936f4bcbL19) [[10]](diffhunk://#diff-50aa11804f5954befb45c10f84bd39d6c706614abf6cf7ba891b35cc936f4bcbL33-R31) [[11]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L160-R159)

**Plugin command improvements:**

* Updated plugin management commands to use the new argument-based `RunWP` interface, and improved the plugin update workflow to handle multiple plugins as a slice of arguments rather than a single string. [[1]](diffhunk://#diff-f9f25f5994c8026d7668e95920efe391e30685a7e3159b96844a8121daaada6dL85-R94) [[2]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L160-R159)
* Clarified the description of the `plugin` command to reflect its broader functionality (listing, installing, updating, removing plugins).

**CLI usability enhancements:**

* Added a `--version` flag to the CLI, allowing users to easily display the current version. Improved help and output logic to show version information and clarify verbosity levels. [[1]](diffhunk://#diff-6830a710a038a65c376a407bfafe6dbcba1561c4994fcfb20aff88375403ac37R13-R32) [[2]](diffhunk://#diff-6830a710a038a65c376a407bfafe6dbcba1561c4994fcfb20aff88375403ac37L31-R46) [[3]](diffhunk://#diff-6830a710a038a65c376a407bfafe6dbcba1561c4994fcfb20aff88375403ac37R60-R61)

**Build system updates:**

* Added a Windows-specific build target (`bin/jman.exe`) to the `Makefile` for improved cross-platform support.