### PR TITLE
fix(wpcli): Disable skip in RunWP for plugin actions

### DIFF
--- a/internal/wpcli/plugins.go
+++ b/internal/wpcli/plugins.go
@@ -12,7 +12,7 @@ import (
 
 // GetPlugins returns a list of installed plugins on the target site.
 func GetPlugins(site models.CliSite) ([]models.WPPlugin, error) {
-	res, err := RunWP(site.SSH, site.Path, true, "plugin", "list", "--format=json")
+	res, err := RunWP(site.SSH, site.Path, false, "plugin", "list", "--format=json")
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return nil, fmt.Errorf("not a WordPress site")
@@ -62,7 +62,7 @@ func AddPlugin(ssh, path, plugin string, activate bool) (bool, error) {
 	if activate {
 		args = append(args, "--activate")
 	}
-	res, err := RunWP(ssh, path, true, args...)
+	res, err := RunWP(ssh, path, false, args...)
 	if err != nil {
 		if strings.Contains(res.Error, "Plugin not found.") {
 			return false, fmt.Errorf("plugin not found")
@@ -91,7 +91,7 @@ func UpdatePlugin(ssh, path string, plugins []string) (int, error) {
 	args = append(args, plugins...)
 	args = append(args, "--format=json")
 
-	res, err := RunWP(ssh, path, true, args...)
+	res, err := RunWP(ssh, path, false, args...)
 	if err != nil {
 		return 0, fmt.Errorf("failed to update plugin: %w (stderr: %s)", err, res.Error)
 	}
@@ -113,7 +113,7 @@ func UpdatePlugin(ssh, path string, plugins []string) (int, error) {
 
 // RemovePlugin uninstalls and deactivates a plugin.
 func RemovePlugin(ssh, path, plugin string) (bool, error) {
-	res, err := RunWP(ssh, path, true, "plugin", "uninstall", plugin, "--deactivate")
+	res, err := RunWP(ssh, path, false, "plugin", "uninstall", plugin, "--deactivate")
 	if err != nil {
 		return false, fmt.Errorf("failed to remove plugin: %w (stderr: %s)", err, res.Error)
 	}

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/JCO-Digital/jman/internal/verbosity"
 )
 
 type RunResult struct {
@@ -44,6 +46,8 @@ func RunWP(ssh, path string, skip bool, args ...string) (RunResult, error) {
 		Output: outBuf.String(),
 		Error:  errBuf.String(),
 	}
+
+	verbosity.Printf(verbosity.Debug, "Command output:\n%s\n\nError output:\n%s", res.Output, res.Error)
 
 	// If cmd.Run() returned an error (non-zero exit code), we return it.
 	if err != nil {


### PR DESCRIPTION
Since plugin updates for paid plugins are often handled by the plugin itself, and plugins and theme might contain over-rides for update actions. Plugins and themes should be loaded for these actions.