### PR TITLE
Vibe/plugin aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ slackChannel = "#alerts" # (optional, defaults to #testing)
 cvssThreshold = 7.0 # (optional, alerts for vulnerabilities with CVSS >= this value)
 vulnThreshold = 7.0 # (optional, alerts for sites with total vulnerabilities >= this value)
 ignoreSites = ["example.com"] # (optional, list of domains to ignore during vulnerability scans)
+
+# Plugin aliases for shorthand installs
+[pluginAliases]
+jquest = "https://github.com/JCO-Digital/jquest-plugin/releases/latest/download/jquest.zip"
 ```
 
 ## Usage
@@ -84,19 +88,19 @@ jman fetch
 
 ### Available Commands
 
-| Command    | Description                                                                         |
-| :--------- | :---------------------------------------------------------------------------------- |
-| `fetch`    | Fetch latest data from SpinupWP and update local cache.                             |
-| `list`     | List cached data from SpinupWP (`servers`, `sites`, or `all`).                      |
-| `wp`       | Run a `wp-cli` command on a target site.                                            |
-| `search`   | Search for a specific term across sites.                                            |
-| `admin`    | Create a new administrator user on target sites.                                    |
-| `plugin`   | Install a plugin on target sites. Supports WordPress.org slugs or custom repo URLs. |
-| `mods`     | Set `DISALLOW_FILE_MODS` to true on target sites.                                   |
-| `alias`    | Create SSH/WP-CLI alias files for all sites or a filtered collection.               |
-| `inactive` | List sites that don't have an active MainWP Child connection.                       |
-| `mainwp`   | Install and configure MainWP on sites.                                              |
-| `vuln`     | Scan for plugin vulnerabilities across all sites.                                   |
+| Command    | Description                                                                     |
+| :--------- | :------------------------------------------------------------------------------ |
+| `fetch`    | Fetch latest data from SpinupWP and update local cache.                         |
+| `list`     | List cached data from SpinupWP (`servers`, `sites`, or `all`).                  |
+| `wp`       | Run a `wp-cli` command on a target site.                                        |
+| `search`   | Search for a specific term across sites.                                        |
+| `admin`    | Create a new administrator user on target sites.                                |
+| `plugin`   | Install a plugin on target sites. Supports slugs, repo URLs, or config aliases. |
+| `mods`     | Set `DISALLOW_FILE_MODS` to true on target sites.                               |
+| `alias`    | Create SSH/WP-CLI alias files for all sites or a filtered collection.           |
+| `inactive` | List sites that don't have an active MainWP Child connection.                   |
+| `mainwp`   | Install and configure MainWP on sites.                                          |
+| `vuln`     | Scan for plugin vulnerabilities across all sites.                               |
 
 ### Examples
 
@@ -109,7 +113,7 @@ jman wp mysite.com plugin list --status=active
 **Install a plugin on a site:**
 
 ```bash
-jman plugin mysite.com akismet
+jman plugin mysite.com install akismet
 ```
 
 **Create an admin user:**

--- a/internal/cache/plugins.go
+++ b/internal/cache/plugins.go
@@ -51,10 +51,10 @@ func GetCachedPlugins(force bool) ([]models.WPPlugin, error) {
 			defer func() { <-sem }()
 			sitePlugins, err := wpcli.GetPlugins(site)
 			if err != nil {
-				verb.PrintErrorf(verb.Normal, "Warning: failed to fetch plugins for site %s: %v\n", site.Name, err)
+				verb.PrintErrorf(verb.Normal, "Warning: failed to fetch plugins for site %s:\n%v\n", verb.Blue(site.Name), verb.Red(err))
 				return
 			}
-			verb.PrintErrorf(verb.Verbose, "Fetched %d plugins for site %s\n", len(sitePlugins), site.Name)
+			verb.PrintErrorf(verb.Verbose, "Fetched %d plugins for site %s\n", len(sitePlugins), verb.Blue(site.Name))
 
 			mu.Lock()
 			plugins = append(plugins, sitePlugins...)

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/JCO-Digital/jman/internal/config"
 	"github.com/JCO-Digital/jman/internal/models"
@@ -67,25 +68,25 @@ func pluginCommand(cmd *cobra.Command, args []string) error {
 		case "list":
 			err := listPlugins(site)
 			if err != nil {
-				verb.Printf(verb.Verbose, "Error listing plugins on %s: %v\n", site.Name, err)
+				verb.Printf(verb.Normal, "Error listing plugins on %s: %v\n", site.Name, err)
 				continue
 			}
 		case "update":
 			updateErr := updatePlugin(site, pluginName)
 			if updateErr != nil {
-				verb.Printf(verb.Verbose, "Error updating plugin on %s: %v\n", site.Name, updateErr)
+				verb.Printf(verb.Normal, "Error updating plugin on %s: %v\n", site.Name, updateErr)
 				continue
 			}
 		case "remove":
 			err := removePlugin(site, pluginName)
 			if err != nil {
-				verb.Printf(verb.Verbose, "Error removing plugin from %s: %v\n", site.Name, err)
+				verb.Printf(verb.Normal, "Error removing plugin from %s: %v\n", site.Name, err)
 				continue
 			}
 		case "install":
 			err := installPlugin(site, pluginName)
 			if err != nil {
-				verb.Printf(verb.Verbose, "Error installing plugin on %s: %v\n", site.Name, err)
+				verb.Printf(verb.Normal, "Error installing plugin on %s: %v\n", site.Name, err)
 				continue
 			}
 		}
@@ -98,7 +99,7 @@ func installPlugin(site models.CliSite, pluginName string) error {
 	verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, site.Name, site.ServerName)
 	success, err := wpcli.AddPlugin(site.SSH, site.Path, pluginName, true)
 	if err != nil {
-		return fmt.Errorf("failed to install plugin: %w", err)
+		return err
 	}
 
 	if success {
@@ -113,7 +114,7 @@ func listPlugins(site models.CliSite) error {
 	verb.Printf(verb.Verbose, "Listing plugins on %s (%s)...\n", site.Name, site.ServerName)
 	plugins, err := wpcli.GetPlugins(site)
 	if err != nil {
-		return fmt.Errorf("failed to get plugins: %w", err)
+		return err
 	}
 
 	if len(plugins) == 0 {
@@ -185,7 +186,7 @@ func getPluginUpdates(site models.CliSite) ([]models.WPPlugin, error) {
 	var updateList []models.WPPlugin
 	plugins, err := wpcli.GetPlugins(site)
 	if err != nil {
-		return updateList, fmt.Errorf("failed to get plugins: %w", err)
+		return updateList, err
 	}
 	for _, plugin := range plugins {
 		if plugin.Update != "" {
@@ -199,7 +200,10 @@ func removePlugin(site models.CliSite, pluginName string) error {
 	verb.Printf(verb.Verbose, "Removing '%s' from %s (%s)...\n", pluginName, site.Name, site.ServerName)
 	success, err := wpcli.RemovePlugin(site.SSH, site.Path, pluginName)
 	if err != nil {
-		return fmt.Errorf("failed to remove plugin: %w", err)
+		if strings.Contains(err.Error(), "plugin could not be found") {
+			return fmt.Errorf("plugin not found")
+		}
+		return err
 	}
 
 	if success {

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -68,25 +68,25 @@ func pluginCommand(cmd *cobra.Command, args []string) error {
 		case "list":
 			err := listPlugins(site)
 			if err != nil {
-				verb.Printf(verb.Normal, "Error listing plugins on %s: %v\n", site.Name, err)
+				verb.Printf(verb.Normal, "Error listing plugins on %s: %v\n", verb.Blue(site.Name), err)
 				continue
 			}
 		case "update":
 			updateErr := updatePlugin(site, pluginName)
 			if updateErr != nil {
-				verb.Printf(verb.Normal, "Error updating plugin on %s: %v\n", site.Name, updateErr)
+				verb.Printf(verb.Normal, "Error updating plugin on %s: %v\n", verb.Blue(site.Name), updateErr)
 				continue
 			}
 		case "remove":
 			err := removePlugin(site, pluginName)
 			if err != nil {
-				verb.Printf(verb.Normal, "Error removing plugin from %s: %v\n", site.Name, err)
+				verb.Printf(verb.Normal, "Error removing plugin from %s: %v\n", verb.Blue(site.Name), err)
 				continue
 			}
 		case "install":
 			err := installPlugin(site, pluginName)
 			if err != nil {
-				verb.Printf(verb.Normal, "Error installing plugin on %s: %v\n", site.Name, err)
+				verb.Printf(verb.Normal, "Error installing plugin on %s: %v\n", verb.Blue(site.Name), err)
 				continue
 			}
 		}
@@ -96,33 +96,33 @@ func pluginCommand(cmd *cobra.Command, args []string) error {
 }
 
 func installPlugin(site models.CliSite, pluginName string) error {
-	verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, site.Name, site.ServerName)
+	verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, verb.Blue(site.Name), site.ServerName)
 	success, err := wpcli.AddPlugin(site.SSH, site.Path, pluginName, true)
 	if err != nil {
 		return err
 	}
 
 	if success {
-		verb.Printf(verb.Normal, "Successfully installed and activated '%s' on %s.\n", pluginName, site.Name)
+		verb.Printf(verb.Normal, "Successfully installed and activated '%s' on %s.\n", verb.Yellow(pluginName), verb.Blue(site.Name))
 	} else {
-		verb.Printf(verb.Normal, "Failed to install '%s' on %s. (It might already be installed)\n", pluginName, site.Name)
+		verb.Printf(verb.Normal, "Failed to install '%s' on %s. (It might already be installed)\n", verb.Yellow(pluginName), verb.Blue(site.Name))
 	}
 	return nil
 }
 
 func listPlugins(site models.CliSite) error {
-	verb.Printf(verb.Verbose, "Listing plugins on %s (%s)...\n", site.Name, site.ServerName)
+	verb.Printf(verb.Verbose, "Listing plugins on %s (%s)...\n", verb.Blue(site.Name), site.ServerName)
 	plugins, err := wpcli.GetPlugins(site)
 	if err != nil {
 		return err
 	}
 
 	if len(plugins) == 0 {
-		verb.Printf(verb.Normal, "No plugins found on %s.\n", site.Name)
+		verb.Printf(verb.Normal, "No plugins found on %s.\n", verb.Blue(site.Name))
 		return nil
 	}
 
-	verb.Printf(verb.Normal, "Plugins on %s:\n", site.Name)
+	verb.Printf(verb.Normal, "Plugins on %s:\n", verb.Blue(site.Name))
 	for _, plugin := range plugins {
 		status := ""
 		if plugin.Status != "active" {
@@ -134,7 +134,6 @@ func listPlugins(site models.CliSite) error {
 		}
 		verb.Printf(verb.Normal, "- %s %s%s %s\n", plugin.Name, status, plugin.Version, update)
 	}
-	//verb.Printf(verb.Normal, "Plugins on %s:\n%s\n", site.Name, plugins)
 	return nil
 }
 
@@ -142,7 +141,7 @@ func updatePlugin(site models.CliSite, pluginName string) error {
 	if pluginName == "" {
 		pluginName = "all"
 	}
-	verb.Printf(verb.Verbose, "Updating '%s' on %s (%s)...\n", pluginName, site.Name, site.ServerName)
+	verb.Printf(verb.Verbose, "Updating '%s' on %s (%s)...\n", verb.Yellow(pluginName), verb.Blue(site.Name), site.ServerName)
 
 	plugins, err := getPluginUpdates(site)
 	if err != nil {
@@ -150,7 +149,7 @@ func updatePlugin(site models.CliSite, pluginName string) error {
 	}
 
 	if len(plugins) == 0 {
-		verb.Printf(verb.Normal, "No plugins to update on %s.\n", site.Name)
+		verb.Printf(verb.Normal, "No plugins to update on %s.\n", verb.Blue(site.Name))
 		return nil
 	}
 	verb.Printf(verb.Normal, "Found %d plugins with updates available:\n", len(plugins))
@@ -166,14 +165,14 @@ func updatePlugin(site models.CliSite, pluginName string) error {
 		verb.Printf(verb.Normal, "- %s (%s -> %s)%s\n", plugin.Name, plugin.Version, plugin.Update, selected)
 	}
 	if len(toUpdate) == 0 {
-		verb.Printf(verb.Normal, "No matching plugins to update on %s.\n", site.Name)
+		verb.Printf(verb.Normal, "No matching plugins to update on %s.\n", verb.Blue(site.Name))
 		return nil
 	}
-	verb.Printf(verb.Normal, "Updating %d plugins on %s...\n", len(toUpdate), site.Name)
+	verb.Printf(verb.Normal, "Updating %d plugins on %s...\n", len(toUpdate), verb.Blue(site.Name))
 
 	updated, err := wpcli.UpdatePlugin(site.SSH, site.Path, toUpdate)
 
-	verb.Printf(verb.Verbose, "Updated %d plugins on %s.\n", updated, site.Name)
+	verb.Printf(verb.Verbose, "Updated %d plugins on %s.\n", updated, verb.Blue(site.Name))
 
 	if err != nil {
 		verb.Printf(verb.Normal, "Error updating plugins\n")
@@ -197,7 +196,7 @@ func getPluginUpdates(site models.CliSite) ([]models.WPPlugin, error) {
 }
 
 func removePlugin(site models.CliSite, pluginName string) error {
-	verb.Printf(verb.Verbose, "Removing '%s' from %s (%s)...\n", pluginName, site.Name, site.ServerName)
+	verb.Printf(verb.Verbose, "Removing '%s' from %s (%s)...\n", verb.Yellow(pluginName), verb.Blue(site.Name), site.ServerName)
 	success, err := wpcli.RemovePlugin(site.SSH, site.Path, pluginName)
 	if err != nil {
 		if strings.Contains(err.Error(), "plugin could not be found") {
@@ -207,9 +206,9 @@ func removePlugin(site models.CliSite, pluginName string) error {
 	}
 
 	if success {
-		verb.Printf(verb.Normal, "Successfully removed '%s' from %s.\n", pluginName, site.Name)
+		verb.Printf(verb.Normal, "Successfully removed '%s' from %s.\n", verb.Yellow(pluginName), verb.Blue(site.Name))
 	} else {
-		verb.Printf(verb.Normal, "Failed to remove '%s' from %s. (It might not be installed)\n", pluginName, site.Name)
+		verb.Printf(verb.Normal, "Failed to remove '%s' from %s. (It might not be installed)\n", verb.Yellow(pluginName), verb.Blue(verb.Blue(site.Name)))
 	}
 	return nil
 }

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -208,7 +208,7 @@ func removePlugin(site models.CliSite, pluginName string) error {
 	if success {
 		verb.Printf(verb.Normal, "Successfully removed '%s' from %s.\n", verb.Yellow(pluginName), verb.Blue(site.Name))
 	} else {
-		verb.Printf(verb.Normal, "Failed to remove '%s' from %s. (It might not be installed)\n", verb.Yellow(pluginName), verb.Blue(verb.Blue(site.Name)))
+		verb.Printf(verb.Normal, "Failed to remove '%s' from %s. (It might not be installed)\n", verb.Yellow(pluginName), verb.Blue(site.Name))
 	}
 	return nil
 }

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/JCO-Digital/jman/internal/config"
 	"github.com/JCO-Digital/jman/internal/models"
 	"github.com/JCO-Digital/jman/internal/search"
 	"github.com/JCO-Digital/jman/internal/verb"
@@ -13,7 +14,7 @@ import (
 var pluginCmd = &cobra.Command{
 	Use:   "plugin <target> [list|install|update|remove] <plugin-name>",
 	Short: "Plugin actions on target sites.",
-	Long:  "List, install, update or remove plugins on target sites. Supports WordPress.org slugs or custom repo URLs.",
+	Long:  "List, install, update or remove plugins on target sites. Supports WordPress.org slugs, custom repo URLs, or aliases defined in config (install only).",
 	Args:  cobra.MinimumNArgs(2),
 	RunE:  pluginCommand,
 }
@@ -42,6 +43,12 @@ func pluginCommand(cmd *cobra.Command, args []string) error {
 	case "install", "remove":
 		if pluginName == "" {
 			return fmt.Errorf("plugin name is required for '%s' operation", operation)
+		}
+		if operation == "install" {
+			if alias, ok := config.Cfg.PluginAliases[pluginName]; ok {
+				verb.Printf(verb.Verbose, "Using alias for '%s': %s\n", pluginName, alias)
+				pluginName = alias
+			}
 		}
 	}
 
@@ -76,22 +83,29 @@ func pluginCommand(cmd *cobra.Command, args []string) error {
 				continue
 			}
 		case "install":
-			verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, site.Name, site.ServerName)
-			success, err := wpcli.AddPlugin(site.SSH, site.Path, pluginName, true)
-
+			err := installPlugin(site, pluginName)
 			if err != nil {
 				verb.Printf(verb.Verbose, "Error installing plugin on %s: %v\n", site.Name, err)
 				continue
 			}
-
-			if success {
-				verb.Printf(verb.Normal, "Successfully installed and activated '%s' on %s.\n", pluginName, site.Name)
-			} else {
-				verb.Printf(verb.Normal, "Failed to install '%s' on %s. (It might already be installed)\n", pluginName, site.Name)
-			}
 		}
 	}
 
+	return nil
+}
+
+func installPlugin(site models.CliSite, pluginName string) error {
+	verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, site.Name, site.ServerName)
+	success, err := wpcli.AddPlugin(site.SSH, site.Path, pluginName, true)
+	if err != nil {
+		return fmt.Errorf("failed to install plugin: %w", err)
+	}
+
+	if success {
+		verb.Printf(verb.Normal, "Successfully installed and activated '%s' on %s.\n", pluginName, site.Name)
+	} else {
+		verb.Printf(verb.Normal, "Failed to install '%s' on %s. (It might already be installed)\n", pluginName, site.Name)
+	}
 	return nil
 }
 

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -68,25 +68,25 @@ func pluginCommand(cmd *cobra.Command, args []string) error {
 		case "list":
 			err := listPlugins(site)
 			if err != nil {
-				verb.Printf(verb.Normal, "Error listing plugins on %s: %v\n", verb.Blue(site.Name), err)
+				verb.Printf(verb.Normal, "Error listing plugins on %s:\n%v\n", verb.Blue(site.Name), verb.Red(err))
 				continue
 			}
 		case "update":
 			updateErr := updatePlugin(site, pluginName)
 			if updateErr != nil {
-				verb.Printf(verb.Normal, "Error updating plugin on %s: %v\n", verb.Blue(site.Name), updateErr)
+				verb.Printf(verb.Normal, "Error updating plugin on %s: %v\n", verb.Blue(site.Name), verb.Red(updateErr))
 				continue
 			}
 		case "remove":
 			err := removePlugin(site, pluginName)
 			if err != nil {
-				verb.Printf(verb.Normal, "Error removing plugin from %s: %v\n", verb.Blue(site.Name), err)
+				verb.Printf(verb.Normal, "Error removing plugin from %s: %v\n", verb.Blue(site.Name), verb.Red(err))
 				continue
 			}
 		case "install":
 			err := installPlugin(site, pluginName)
 			if err != nil {
-				verb.Printf(verb.Normal, "Error installing plugin on %s: %v\n", verb.Blue(site.Name), err)
+				verb.Printf(verb.Normal, "Error installing plugin on %s: %v\n", verb.Blue(site.Name), verb.Red(err))
 				continue
 			}
 		}
@@ -96,7 +96,7 @@ func pluginCommand(cmd *cobra.Command, args []string) error {
 }
 
 func installPlugin(site models.CliSite, pluginName string) error {
-	verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, verb.Blue(site.Name), site.ServerName)
+	verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, verb.Blue(site.Name), verb.Yellow(site.ServerName))
 	success, err := wpcli.AddPlugin(site.SSH, site.Path, pluginName, true)
 	if err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,15 +24,16 @@ type Runtime struct {
 
 // AppConfig represents the user-defined settings mapped from the config file or environment variables.
 type AppConfig struct {
-	TokenSpinup         string   `toml:"tokenSpinup" mapstructure:"tokenSpinup"`
-	TokenSlack          string   `toml:"slackToken" mapstructure:"slackToken"`
-	SlackChannel        string   `toml:"slackChannel" mapstructure:"slackChannel"`
-	SlackMonitorChannel string   `toml:"slackMonitorChannel" mapstructure:"slackMonitorChannel"`
-	MonitorThreshold    int      `toml:"monitorThreshold" mapstructure:"monitorThreshold"`
-	MonitorTimeout      int      `toml:"monitorTimeout" mapstructure:"monitorTimeout"`
-	CVSSThreshold       float64  `toml:"cvssThreshold" mapstructure:"cvssThreshold"`
-	VulnThreshold       float64  `toml:"vulnThreshold" mapstructure:"vulnThreshold"`
-	IgnoreSites         []string `toml:"ignoreSites" mapstructure:"ignoreSites"`
+	TokenSpinup         string            `toml:"tokenSpinup" mapstructure:"tokenSpinup"`
+	TokenSlack          string            `toml:"slackToken" mapstructure:"slackToken"`
+	SlackChannel        string            `toml:"slackChannel" mapstructure:"slackChannel"`
+	SlackMonitorChannel string            `toml:"slackMonitorChannel" mapstructure:"slackMonitorChannel"`
+	MonitorThreshold    int               `toml:"monitorThreshold" mapstructure:"monitorThreshold"`
+	MonitorTimeout      int               `toml:"monitorTimeout" mapstructure:"monitorTimeout"`
+	CVSSThreshold       float64           `toml:"cvssThreshold" mapstructure:"cvssThreshold"`
+	VulnThreshold       float64           `toml:"vulnThreshold" mapstructure:"vulnThreshold"`
+	IgnoreSites         []string          `toml:"ignoreSites" mapstructure:"ignoreSites"`
+	PluginAliases       map[string]string `toml:"pluginAliases" mapstructure:"pluginAliases"`
 }
 
 var (
@@ -68,6 +69,7 @@ func loadConfig() error {
 	viper.SetDefault("cvssThreshold", 7.0)
 	viper.SetDefault("vulnThreshold", 7.0)
 	viper.SetDefault("ignoreSites", []string{})
+	viper.SetDefault("pluginAliases", map[string]string{})
 
 	// Viper configuration
 	viper.SetConfigName("config")

--- a/internal/wpcli/plugins.go
+++ b/internal/wpcli/plugins.go
@@ -3,7 +3,6 @@ package wpcli
 import (
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/JCO-Digital/jman/internal/models"
@@ -14,10 +13,7 @@ import (
 func GetPlugins(site models.CliSite) ([]models.WPPlugin, error) {
 	res, err := RunWP(site.SSH, site.Path, false, "plugin", "list", "--format=json")
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			return nil, fmt.Errorf("not a WordPress site")
-		}
-		return nil, fmt.Errorf("unknown error: %w", err)
+		return nil, err
 	}
 
 	output := res.Output

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -49,24 +49,18 @@ func RunWP(ssh, path string, skip bool, args ...string) (RunResult, error) {
 
 	verb.Printf(verb.Debug, "Command output:\n%s\n\nError output:\n%s", res.Output, res.Error)
 
-	// If cmd.Run() returned an error (non-zero exit code), we return it.
+	// If cmd.Run() returned an error (non-zero exit code), look for the first error line.
 	if err != nil {
-		return res, err
-	}
-
-	// wp-cli sometimes exits with 0 even on certain failures (like connection errors),
-	// so we check the first non-empty stderr line for the "Error:" prefix to detect these cases.
-	if res.Error != "" {
-		for line := range strings.SplitSeq(res.Error, "\n") {
-			trimmed := strings.TrimSpace(line)
-			if trimmed == "" {
-				continue
+		if res.Error != "" {
+			for line := range strings.SplitSeq(res.Error, "\n") {
+				trimmed := strings.TrimSpace(line)
+				if trimmed == "" {
+					continue
+				}
+				if strings.HasPrefix(trimmed, "Error:") || strings.HasPrefix(trimmed, "Fatal error:") {
+					return res, fmt.Errorf("%s", trimmed)
+				}
 			}
-			if strings.HasPrefix(trimmed, "Error:") {
-				return res, fmt.Errorf("wp-cli error: %s", trimmed)
-			}
-			// Only consider the first non-empty line.
-			break
 		}
 	}
 

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -62,6 +62,7 @@ func RunWP(ssh, path string, skip bool, args ...string) (RunResult, error) {
 				}
 			}
 		}
+		return res, err
 	}
 
 	return res, nil


### PR DESCRIPTION
This pull request introduces plugin alias support and improves error handling and output formatting for plugin commands. The main enhancements allow users to define plugin aliases in the config for easier installs, and provide clearer, color-coded output and error messages across plugin operations.

Plugin alias support:

* Added `PluginAliases` to the `AppConfig` struct and TOML config, allowing users to define shorthand names for plugin URLs. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR36) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR72)
* Updated the `plugin` command to resolve aliases during install operations, so users can use custom names defined in config. [[1]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L16-R18) [[2]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901R48-R53)

Error handling and output improvements:

* Enhanced error messages and output formatting for plugin commands (`install`, `list`, `update`, `remove`) to use color coding and more consistent verbosity. [[1]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L63-R125) [[2]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L122-R152) [[3]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L154-R175) [[4]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L185-R211) [[5]](diffhunk://#diff-51621c42b4aea8d12a426077a555c544019e4658ff8f041572f1fb973c91c406L54-R57)
* Simplified error handling in `wpcli.GetPlugins` and `wpcli.RunWP` to return errors directly and detect WordPress-specific errors more reliably. [[1]](diffhunk://#diff-f9f25f5994c8026d7668e95920efe391e30685a7e3159b96844a8121daaada6dL17-R16) [[2]](diffhunk://#diff-9f6b5a921ec2474091809be7b8a4f0e809783ebb6ee3f44a2a38b2146241a5d1L52-L69)

Documentation updates:

* Updated `README.md` to document plugin alias usage, clarify command syntax, and describe expanded plugin install support. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R72) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R98) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R116)