### PR TITLE
fix(update): Use AppVersion for current version check

### DIFF
--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -28,7 +28,7 @@ var updateCmd = &cobra.Command{
 			}
 		}
 
-		currentVersion := config.RunData.Version
+		currentVersion := config.AppVersion
 		verb.Printf(verb.Normal, "Current jman version: %s\n", verb.Blue(currentVersion))
 
 		// Use a dummy version if running in dev to see what the latest version is


### PR DESCRIPTION
The `update` command was incorrectly using `config.RunData.Version` to determine the current jman version. This commit changes it to use `config.AppVersion` which is the correct field for this purpose.