### PR TITLE
Fix/plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,24 @@ _Note: `jman` was recently rewritten in Go for improved performance, concurrent 
 
 ## Installation
 
-You can install `jman` directly via the Go toolchain:
+### Option A: Download a prebuilt binary (recommended)
+
+1. Open the latest release page:
+   https://github.com/JCO-Digital/jman/releases/latest
+2. Download the executable for your OS/architecture.
+3. Extract it.
+4. Move the `jman` binary to a directory in your `PATH` (for example `~/.local/bin` or `/usr/local/bin` if you want it system wide).
+
+Example (Linux/macOS):
 
 ```bash
-go install github.com/JCO-Digital/jman/cmd/jman@latest
+chmod +x jman
+mv jman ~/.local/bin/jman
 ```
 
-### Prerequisites
+### Option B: Build from source
 
-- Go (v1.21 or later recommended)
-- SSH access configured for your SpinupWP servers.
-- `wp-cli` available on the target servers.
-
-### Building from source
+If you prefer building locally, clone the repository and build with the project’s standard build process, then place the resulting `jman` binary in your `PATH`.
 
 1. Clone the repository:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ If you prefer building locally, clone the repository and build with the projectâ
 
 If you don't use `make install`, the compiled binary will be generated at `./bin/jman`.
 
+### Prerequisites
+
+- SSH access configured for your SpinupWP servers.
+- `wp-cli` available locally and on the target servers.
+- Go (needed if building from source, v1.25 or later recommended)
+
 ## Configuration
 
 `jman` uses a TOML configuration file located in your XDG config directory (typically `~/.config/jman/config.toml` on Linux and macOS).

--- a/internal/cache/plugins.go
+++ b/internal/cache/plugins.go
@@ -49,7 +49,7 @@ func GetCachedPlugins(force bool) ([]models.WPPlugin, error) {
 		wg.Go(func() {
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			sitePlugins, err := wpcli.GetPlugins(site)
+			sitePlugins, err := wpcli.GetPlugins(site, true)
 			if err != nil {
 				verb.PrintErrorf(verb.Normal, "Warning: failed to fetch plugins for site %s:\n%v\n", verb.Blue(site.Name), verb.Red(err))
 				return

--- a/internal/commands/admin.go
+++ b/internal/commands/admin.go
@@ -37,9 +37,9 @@ var adminCmd = &cobra.Command{
 			}
 
 			if password != "" {
-				verb.Printf(verb.Verbose, "Successfully created user '%s' with password: %s\n", username, password)
+				verb.Printf(verb.Normal, "Successfully created user '%s' with password: %s\n", username, password)
 			} else {
-				verb.Printf(verb.Verbose, "User '%s' may already exist or creation failed without a returned password.\n", username)
+				verb.Printf(verb.Normal, "User '%s' may already exist or creation failed without a returned password.\n", username)
 			}
 		}
 

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -114,7 +114,7 @@ func installPlugin(site models.CliSite, pluginName string) error {
 
 func listPlugins(site models.CliSite) error {
 	verb.Printf(verb.Verbose, "Listing plugins on %s (%s)...\n", verb.Blue(site.Name), site.ServerName)
-	plugins, err := wpcli.GetPlugins(site)
+	plugins, err := wpcli.GetPlugins(site, false)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func updatePlugin(site models.CliSite, pluginName string) error {
 
 func getPluginUpdates(site models.CliSite) ([]models.WPPlugin, error) {
 	var updateList []models.WPPlugin
-	plugins, err := wpcli.GetPlugins(site)
+	plugins, err := wpcli.GetPlugins(site, false)
 	if err != nil {
 		return updateList, err
 	}

--- a/internal/commands/wp.go
+++ b/internal/commands/wp.go
@@ -28,7 +28,7 @@ var wpCmd = &cobra.Command{
 
 		for _, site := range sites {
 			verb.Printf(verb.Verbose, "\n=== %s (%s) ===\n", site.Name, site.ServerName)
-			res, err := wpcli.RunWP(site.SSH, site.Path, false, args[1:]...)
+			res, err := wpcli.RunWP(wpcli.CliOptions{SSH: site.SSH, Path: site.Path}, args[1:]...)
 
 			if res.Output != "" {
 				verb.Println(verb.Quiet, res.Output)

--- a/internal/wpcli/core.go
+++ b/internal/wpcli/core.go
@@ -18,7 +18,7 @@ type CoreUpdate struct {
 
 // Check WordPress core for updates and return the available updates if any.
 func CheckCore(ssh, path string) ([]CoreUpdate, error) {
-	res, err := RunWP(ssh, path, true, "core", "check-update", "--format=json")
+	res, err := RunWP(CliOptions{SSH: ssh, Path: path}, "core", "check-update", "--format=json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to check core updates: %w (stderr: %s)", err, res.Error)
 	}
@@ -52,7 +52,7 @@ func UpdateCore(ssh, path string) (CoreUpdateResult, error) {
 		Language: "",
 	}
 
-	res, err := RunWP(ssh, path, true, "core", "update", "--minor")
+	res, err := RunWP(CliOptions{SSH: ssh, Path: path}, "core", "update", "--minor")
 	if err != nil {
 		return result, fmt.Errorf("failed to update core: %w (stderr: %s)", err, res.Error)
 	}
@@ -75,7 +75,7 @@ func UpdateCore(ssh, path string) (CoreUpdateResult, error) {
 	}
 	result.Success = true
 
-	res, err = RunWP(ssh, path, true, "core", "update-db")
+	res, err = RunWP(CliOptions{SSH: ssh, Path: path}, "core", "update-db")
 	if err != nil {
 		return result, fmt.Errorf("failed to update core database: %w (stderr: %s)", err, res.Error)
 	}
@@ -86,7 +86,7 @@ func UpdateCore(ssh, path string) (CoreUpdateResult, error) {
 
 // CoreVersion returns the current WordPress core version on the target site.
 func CoreVersion(ssh, path string) (string, error) {
-	res, err := RunWP(ssh, path, true, "core", "version")
+	res, err := RunWP(CliOptions{SSH: ssh, Path: path}, "core", "version")
 	if err != nil {
 		return "", fmt.Errorf("failed to show core version: %w (stderr: %s)", err, res.Error)
 	}

--- a/internal/wpcli/plugins.go
+++ b/internal/wpcli/plugins.go
@@ -10,8 +10,8 @@ import (
 )
 
 // GetPlugins returns a list of installed plugins on the target site.
-func GetPlugins(site models.CliSite, skip bool) ([]models.WPPlugin, error) {
-	res, err := RunWP(site.SSH, site.Path, skip, "plugin", "list", "--format=json")
+func GetPlugins(site models.CliSite, skipPlugins bool) ([]models.WPPlugin, error) {
+	res, err := RunWP(CliOptions{SSH: site.SSH, Path: site.Path, IncludePlugins: !skipPlugins}, "plugin", "list", "--format=json")
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func AddPlugin(ssh, path, plugin string, activate bool) (bool, error) {
 	if activate {
 		args = append(args, "--activate")
 	}
-	res, err := RunWP(ssh, path, false, args...)
+	res, err := RunWP(CliOptions{SSH: ssh, Path: path, IncludePlugins: true}, args...)
 	if err != nil {
 		if strings.Contains(res.Error, "Plugin not found.") {
 			return false, fmt.Errorf("plugin not found")
@@ -87,7 +87,7 @@ func UpdatePlugin(ssh, path string, plugins []string) (int, error) {
 	args = append(args, plugins...)
 	args = append(args, "--format=json")
 
-	res, err := RunWP(ssh, path, false, args...)
+	res, err := RunWP(CliOptions{SSH: ssh, Path: path, IncludePlugins: true}, args...)
 	if err != nil {
 		return 0, fmt.Errorf("failed to update plugin: %w (stderr: %s)", err, res.Error)
 	}
@@ -109,7 +109,7 @@ func UpdatePlugin(ssh, path string, plugins []string) (int, error) {
 
 // RemovePlugin uninstalls and deactivates a plugin.
 func RemovePlugin(ssh, path, plugin string) (bool, error) {
-	res, err := RunWP(ssh, path, false, "plugin", "uninstall", plugin, "--deactivate")
+	res, err := RunWP(CliOptions{SSH: ssh, Path: path, IncludePlugins: true}, "plugin", "uninstall", plugin, "--deactivate")
 	if err != nil {
 		return false, fmt.Errorf("failed to remove plugin: %w (stderr: %s)", err, res.Error)
 	}

--- a/internal/wpcli/plugins.go
+++ b/internal/wpcli/plugins.go
@@ -10,8 +10,8 @@ import (
 )
 
 // GetPlugins returns a list of installed plugins on the target site.
-func GetPlugins(site models.CliSite) ([]models.WPPlugin, error) {
-	res, err := RunWP(site.SSH, site.Path, false, "plugin", "list", "--format=json")
+func GetPlugins(site models.CliSite, skip bool) ([]models.WPPlugin, error) {
+	res, err := RunWP(site.SSH, site.Path, skip, "plugin", "list", "--format=json")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -9,6 +9,13 @@ import (
 	"github.com/JCO-Digital/jman/internal/verb"
 )
 
+type CliOptions struct {
+	SSH            string
+	Path           string
+	IncludePlugins bool
+	IncludeThemes  bool
+}
+
 type RunResult struct {
 	Output string
 	Error  string
@@ -16,21 +23,24 @@ type RunResult struct {
 
 // RunWP executes a wp-cli command. If ssh is provided, it runs via SSH.
 // It uses variadic arguments to avoid shell injection and quoting issues.
-func RunWP(ssh, path string, skip bool, args ...string) (RunResult, error) {
+func RunWP(opts CliOptions, args ...string) (RunResult, error) {
 	if _, err := exec.LookPath("wp"); err != nil {
 		return RunResult{}, fmt.Errorf("wp-cli executable not found in PATH")
 	}
 
 	var fullArgs []string
-	if ssh != "" {
-		fullArgs = append(fullArgs, fmt.Sprintf("--ssh=%s", ssh))
+	if opts.SSH != "" {
+		fullArgs = append(fullArgs, fmt.Sprintf("--ssh=%s", opts.SSH))
 	}
-	if path != "" {
-		fullArgs = append(fullArgs, fmt.Sprintf("--path=%s", path))
+	if opts.Path != "" {
+		fullArgs = append(fullArgs, fmt.Sprintf("--path=%s", opts.Path))
 	}
 
-	if skip {
-		fullArgs = append(fullArgs, "--skip-plugins", "--skip-themes")
+	if !opts.IncludePlugins {
+		fullArgs = append(fullArgs, "--skip-plugins")
+	}
+	if !opts.IncludeThemes {
+		fullArgs = append(fullArgs, "--skip-themes")
 	}
 
 	fullArgs = append(fullArgs, args...)
@@ -70,7 +80,7 @@ func RunWP(ssh, path string, skip bool, args ...string) (RunResult, error) {
 
 // AddUser creates a new user on the target WordPress site.
 func AddUser(ssh, path, username, email, role string) (string, error) {
-	res, err := RunWP(ssh, path, true, "user", "create", username, email, "--role="+role)
+	res, err := RunWP(CliOptions{SSH: ssh, Path: path}, "user", "create", username, email, "--role="+role)
 	if err != nil {
 		return "", fmt.Errorf("failed to add user: %w (stderr: %s)", err, res.Error)
 	}
@@ -86,7 +96,7 @@ func AddUser(ssh, path, username, email, role string) (string, error) {
 
 // ResetUserPassword resets the password for a given user.
 func ResetUserPassword(ssh, path, username string) (string, error) {
-	res, err := RunWP(ssh, path, true, "user", "reset-password", username, "--porcelain")
+	res, err := RunWP(CliOptions{SSH: ssh, Path: path}, "user", "reset-password", username, "--porcelain")
 	if err != nil {
 		return "", fmt.Errorf("failed to reset password: %w (stderr: %s)", err, res.Error)
 	}
@@ -99,6 +109,6 @@ func SetDisallowFileMods(ssh, path string, value bool) error {
 	if value {
 		valStr = "true"
 	}
-	_, err := RunWP(ssh, path, true, "config", "set", "--raw", "DISALLOW_FILE_MODS", valStr)
+	_, err := RunWP(CliOptions{SSH: ssh, Path: path}, "config", "set", "--raw", "DISALLOW_FILE_MODS", valStr)
 	return err
 }


### PR DESCRIPTION
This pull request introduces several improvements to the installation instructions in the `README.md` and refactors the plugin listing logic to provide more control over command skipping and verbosity. The most significant changes are the enhanced installation instructions for users and the refactoring of the `GetPlugins` function to accept a new parameter, along with updates to all its call sites.

**Documentation improvements:**

* The `README.md` now provides clearer, step-by-step installation instructions, including a recommended option to download prebuilt binaries and an alternative to build from source. This makes it easier for users to get started with `jman`.

**Plugin listing and command refactoring:**

* The `GetPlugins` function in `internal/wpcli/plugins.go` now accepts a `skip` boolean parameter, allowing callers to control whether certain command steps are skipped. All call sites have been updated to pass the appropriate value for this parameter.
  - Calls in `internal/commands/plugin.go` for listing and updating plugins now explicitly pass `false` to avoid skipping steps. [[1]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L117-R117) [[2]](diffhunk://#diff-76822c5b8719993abb0c1821ebd42c1b3fad6028ab439a492a1fc6a68509f901L188-R188)
  - The call in `internal/cache/plugins.go` passes `true`, likely to optimize or cache plugin retrieval.

**User feedback and verbosity:**

* Changed user feedback in `internal/commands/admin.go` to use normal verbosity for user creation messages instead of verbose, ensuring important information is visible by default.