### PR TITLE
Feat/vuln api

### DIFF
--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/JCO-Digital/jman/internal/cache"
 	"github.com/JCO-Digital/jman/internal/db"
 	"github.com/JCO-Digital/jman/internal/models"
+	"github.com/JCO-Digital/jman/internal/vuln"
 )
 
 // PluginsHandler returns the list of cached WordPress plugins.
@@ -83,27 +84,67 @@ func SitesHandler(w http.ResponseWriter, r *http.Request) {
 	WriteJSON(w, http.StatusOK, sites)
 }
 
-// VulnsHandler returns the cached vulnerability data for a specific plugin.
+// VulnsHandler returns the filtered and enriched vulnerability data for managed plugins.
+// If a "plugin" query parameter is provided, it returns vulnerabilities for that plugin.
+// Otherwise, it returns all active vulnerabilities across all managed sites.
 func VulnsHandler(w http.ResponseWriter, r *http.Request) {
-	plugin := r.URL.Query().Get("plugin")
-	if plugin == "" {
-		WriteError(w, http.StatusBadRequest, "Missing required query parameter: plugin")
+	pluginName := r.URL.Query().Get("plugin")
+	if pluginName == "" {
+		reports, err := vuln.ProcessVulnerabilities()
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to process vulnerabilities: %v", err))
+			return
+		}
+
+		// Enrich each vulnerability with its affected sites for UI convenience.
+		for i := range reports {
+			reports[i].Vulnerability.Sites = reports[i].Sites
+		}
+
+		WriteJSON(w, http.StatusOK, reports)
 		return
 	}
 
 	// Sanitize the plugin name to prevent path traversal.
-	// We only want the base filename.
-	plugin = filepath.Base(plugin)
-	if plugin == "." || plugin == ".." || plugin == "/" {
+	pluginName = filepath.Base(pluginName)
+	if pluginName == "." || pluginName == ".." || pluginName == "/" {
 		WriteError(w, http.StatusBadRequest, "Invalid plugin name")
 		return
 	}
 
-	var vulnData models.VulnResponse
-	filename := fmt.Sprintf("vulnerabilities/%s", plugin)
-	if err := cache.ReadJSONCache(filename, &vulnData, cache.DefaultTTL); err != nil {
-		WriteError(w, http.StatusNotFound, fmt.Sprintf("Cache missing or expired for plugin %q: %v. Run 'jman vuln %s' to fetch data.", plugin, err, plugin))
+	// Get vulnerability data first to get metadata.
+	vulnResponse, err := cache.GetCachedVulnerabilities(pluginName)
+	if err != nil || vulnResponse == nil || vulnResponse.Data == nil {
+		WriteError(w, http.StatusNotFound, fmt.Sprintf("Vulnerability data not found for plugin %q.", pluginName))
 		return
 	}
-	WriteJSON(w, http.StatusOK, vulnData)
+
+	pluginData, err := cache.GetCachedPluginData()
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to get plugin data: %v", err))
+		return
+	}
+
+	var targetSites []models.PluginSite
+	for _, p := range pluginData {
+		if p.Name == pluginName {
+			targetSites = p.Sites
+			break
+		}
+	}
+
+	reports := vuln.GetVulnerabilityReportsForPlugin(pluginName, targetSites)
+
+	// Prepare the response data based on the original structure but filtered.
+	// We return a copy of VulnData with filtered and enriched vulnerabilities.
+	response := *vulnResponse.Data
+	response.Vulnerability = []models.Vulnerability{}
+
+	for _, report := range reports {
+		v := report.Vulnerability
+		v.Sites = report.Sites
+		response.Vulnerability = append(response.Vulnerability, v)
+	}
+
+	WriteJSON(w, http.StatusOK, response)
 }

--- a/internal/cache/plugins.go
+++ b/internal/cache/plugins.go
@@ -95,6 +95,15 @@ func GetCachedPluginData() ([]models.WPPluginData, error) {
 		return nil, err
 	}
 
+	sites, err := GetSiteList()
+	if err != nil {
+		return nil, err
+	}
+	siteNames := make(map[int]string)
+	for _, s := range sites {
+		siteNames[s.ID] = s.Name
+	}
+
 	var pluginData []models.WPPluginData
 	pluginMap := make(map[string]*models.WPPluginData)
 
@@ -114,8 +123,9 @@ func GetCachedPluginData() ([]models.WPPluginData, error) {
 		}
 
 		data.Sites = append(data.Sites, models.PluginSite{
-			SiteID:  plugin.SiteID,
-			Version: plugin.Version,
+			SiteID:   plugin.SiteID,
+			SiteName: siteNames[plugin.SiteID],
+			Version:  plugin.Version,
 		})
 	}
 

--- a/internal/models/plugin.go
+++ b/internal/models/plugin.go
@@ -12,8 +12,9 @@ type WPPlugin struct {
 
 // PluginSite represents a specific site where a plugin is installed and its version.
 type PluginSite struct {
-	SiteID  int    `json:"site_id"`
-	Version string `json:"version"`
+	SiteID   int    `json:"site_id"`
+	SiteName string `json:"site_name,omitempty"`
+	Version  string `json:"version"`
 }
 
 // WPPluginData groups sites by a specific plugin.

--- a/internal/models/vuln.go
+++ b/internal/models/vuln.go
@@ -58,12 +58,13 @@ type Operator struct {
 }
 
 type Vulnerability struct {
-	Uuid        string   `json:"uuid"`
-	Name        string   `json:"name"`
-	Description *string  `json:"description"`
-	Operator    Operator `json:"operator"`
-	Source      []Source `json:"source"`
-	Impact      *Impact  `json:"impact,omitempty"`
+	Uuid        string       `json:"uuid"`
+	Name        string       `json:"name"`
+	Description *string      `json:"description"`
+	Operator    Operator     `json:"operator"`
+	Source      []Source     `json:"source"`
+	Impact      *Impact      `json:"impact,omitempty"`
+	Sites       []PluginSite `json:"sites,omitempty"`
 }
 
 type VulnData struct {

--- a/internal/models/vuln.go
+++ b/internal/models/vuln.go
@@ -84,11 +84,14 @@ type VulnResponse struct {
 
 type VulnReport struct {
 	Plugin        string        `json:"plugin"`
+	Slug          string        `json:"slug"`
+	PluginName    string        `json:"plugin_name"`
 	Vulnerability Vulnerability `json:"vulnerability"`
 	Sites         []PluginSite  `json:"sites"`
 }
 
 type VulnPlugin struct {
+	PluginName    string          `json:"plugin_name"`
 	Version       string          `json:"version"`
 	Cvss          *float64        `json:"cvss"`
 	Vulnerability []Vulnerability `json:"vulnerability"`

--- a/internal/vuln/vuln.go
+++ b/internal/vuln/vuln.go
@@ -182,14 +182,78 @@ func buildSiteList() (map[int]map[string]*models.VulnPlugin, error) {
 	return sitesMap, nil
 }
 
+// IsVersionAffected checks if a specific version is within the range defined by a vulnerability operator.
+func IsVersionAffected(ver string, op models.Operator) bool {
+	// Default bounds:
+	// - min: "0" (effectively no lower bound for semantic versions)
+	// - max: ""  (treated as unbounded upper range)
+	minVer := "0"
+	minOp := "ge"
+	if op.MinVersion != nil {
+		minVer = *op.MinVersion
+		if op.MinOperator != nil {
+			minOp = *op.MinOperator
+		}
+	}
+	maxVer := ""
+	maxOp := "le"
+	if op.MaxVersion != nil {
+		maxVer = *op.MaxVersion
+		if op.MaxOperator != nil {
+			maxOp = *op.MaxOperator
+		}
+	}
+
+	if maxVer != "" {
+		if maxTest, _ := versionCompare(ver, maxVer, maxOp); !maxTest {
+			return false
+		}
+	}
+	if minTest, _ := versionCompare(ver, minVer, minOp); !minTest {
+		return false
+	}
+
+	return true
+}
+
+// GetVulnerabilityReportsForPlugin finds all vulnerabilities affecting the provided sites for a given plugin.
+func GetVulnerabilityReportsForPlugin(pluginName string, sites []models.PluginSite) []models.VulnReport {
+	var reports []models.VulnReport
+
+	vulnResponse, err := cache.GetCachedVulnerabilities(pluginName)
+	if err != nil || vulnResponse == nil || vulnResponse.Data == nil {
+		// Missing or invalid vulnerability cache for this plugin; skip it.
+		return nil
+	}
+
+	for _, vulnerability := range vulnResponse.Data.Vulnerability {
+		report := models.VulnReport{
+			Plugin:        pluginName,
+			Vulnerability: vulnerability,
+			Sites:         []models.PluginSite{},
+		}
+		if vulnResponse.Data.Name != nil {
+			report.Plugin = *vulnResponse.Data.Name
+		}
+
+		// Add every site whose installed plugin version falls inside the affected range.
+		for _, site := range sites {
+			if IsVersionAffected(site.Version, vulnerability.Operator) {
+				report.Sites = append(report.Sites, site)
+			}
+		}
+
+		// Keep only vulnerabilities that affect at least one known site.
+		if len(report.Sites) > 0 {
+			reports = append(reports, report)
+		}
+	}
+
+	return reports
+}
+
 // ProcessVulnerabilities loads cached plugin inventory and vulnerability data, then
 // determines which sites are affected by which vulnerabilities based on version ranges.
-//
-// Matching rule per site:
-//   - site.Version <= vulnerability.maxVersion (or max version is unbounded), and
-//   - vulnerability.minVersion <= site.Version.
-//
-// For each vulnerability with at least one affected site, a models.VulnReport is emitted.
 func ProcessVulnerabilities() ([]models.VulnReport, error) {
 	var reports []models.VulnReport
 
@@ -200,58 +264,7 @@ func ProcessVulnerabilities() ([]models.VulnReport, error) {
 
 	for _, plugin := range pluginData {
 		verb.Printf(verb.Verbose, "Processing plugin: %s\n", plugin.Name)
-		vulnResponse, err := cache.GetCachedVulnerabilities(plugin.Name)
-		if err != nil || vulnResponse == nil || vulnResponse.Data == nil {
-			// Missing or invalid vulnerability cache for this plugin; skip it.
-			continue
-		}
-
-		for _, vulnerability := range vulnResponse.Data.Vulnerability {
-			report := models.VulnReport{
-				Plugin:        *vulnResponse.Data.Name,
-				Vulnerability: vulnerability,
-				Sites:         []models.PluginSite{},
-			}
-
-			// Default bounds:
-			// - min: "0" (effectively no lower bound for semantic versions)
-			// - max: ""  (treated as unbounded upper range)
-			minVer := "0"
-			minOp := "ge"
-			if vulnerability.Operator.MinVersion != nil {
-				minVer = *vulnerability.Operator.MinVersion
-				if vulnerability.Operator.MinOperator != nil {
-					minOp = *vulnerability.Operator.MinOperator
-				}
-			}
-			maxVer := ""
-			maxOp := "le"
-			if vulnerability.Operator.MaxVersion != nil {
-				maxVer = *vulnerability.Operator.MaxVersion
-				if vulnerability.Operator.MaxOperator != nil {
-					maxOp = *vulnerability.Operator.MaxOperator
-				}
-			}
-
-			// Add every site whose installed plugin version falls inside [minVer, maxVer].
-			for _, site := range plugin.Sites {
-				if maxVer != "" {
-					if maxTest, _ := versionCompare(site.Version, maxVer, maxOp); !maxTest {
-						continue
-					}
-				}
-				if minTest, _ := versionCompare(site.Version, minVer, minOp); !minTest {
-					continue
-				}
-
-				report.Sites = append(report.Sites, site)
-			}
-
-			// Keep only vulnerabilities that affect at least one known site.
-			if len(report.Sites) > 0 {
-				reports = append(reports, report)
-			}
-		}
+		reports = append(reports, GetVulnerabilityReportsForPlugin(plugin.Name, plugin.Sites)...)
 	}
 
 	return reports, nil

--- a/internal/vuln/vuln.go
+++ b/internal/vuln/vuln.go
@@ -160,14 +160,15 @@ func buildSiteList() (map[int]map[string]*models.VulnPlugin, error) {
 				sitesMap[site.SiteID] = currentSite
 			}
 
-			currentPlugin, ok := currentSite[report.Plugin]
+			currentPlugin, ok := currentSite[report.Slug]
 			if !ok {
 				currentPlugin = &models.VulnPlugin{
+					PluginName:    report.PluginName,
 					Version:       site.Version,
 					Cvss:          &cvss,
 					Vulnerability: []models.Vulnerability{},
 				}
-				currentSite[report.Plugin] = currentPlugin
+				currentSite[report.Slug] = currentPlugin
 			}
 
 			// Keep the maximum CVSS observed for this plugin on this site.
@@ -229,11 +230,13 @@ func GetVulnerabilityReportsForPlugin(pluginName string, sites []models.PluginSi
 	for _, vulnerability := range vulnResponse.Data.Vulnerability {
 		report := models.VulnReport{
 			Plugin:        pluginName,
+			Slug:          pluginName,
+			PluginName:    pluginName,
 			Vulnerability: vulnerability,
 			Sites:         []models.PluginSite{},
 		}
 		if vulnResponse.Data.Name != nil {
-			report.Plugin = *vulnResponse.Data.Name
+			report.PluginName = *vulnResponse.Data.Name
 		}
 
 		// Add every site whose installed plugin version falls inside the affected range.
@@ -286,7 +289,7 @@ func formatReport(report models.VulnReport) (string, error) {
 	infoLink := ""
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Plugin: %s\n", utils.CleanHTML(report.Plugin))
+	fmt.Fprintf(&sb, "Plugin: %s\n", utils.CleanHTML(report.PluginName))
 
 	// Pull the first useful values from source metadata.
 	// Non-CVE names are preferred for readability when available.
@@ -345,9 +348,13 @@ func formatSiteReport(siteTitle string, plugins map[string]*models.VulnPlugin) s
 	}
 	sort.Strings(keys)
 
-	for _, pluginName := range keys {
-		info := plugins[pluginName]
-		fmt.Fprintf(&sb, "  %s - %s\n", utils.CleanHTML(pluginName), info.Version)
+	for _, pluginSlug := range keys {
+		info := plugins[pluginSlug]
+		displayName := info.PluginName
+		if displayName == "" {
+			displayName = pluginSlug
+		}
+		fmt.Fprintf(&sb, "  %s - %s\n", utils.CleanHTML(displayName), info.Version)
 		fmt.Fprintf(&sb, "    Vulnerabilities: %d\n", len(info.Vulnerability))
 		if info.Cvss != nil {
 			fmt.Fprintf(&sb, "    Highest CVSS: %.1f\n", *info.Cvss)


### PR DESCRIPTION
This pull request refactors and enhances the way vulnerability data is handled and presented for WordPress plugins across managed sites. The main improvements are the enrichment of vulnerability responses with affected site details, the addition of plugin metadata, and a clearer separation of logic for vulnerability processing and reporting. These changes improve both the API's flexibility and the clarity of data returned to the frontend.

**API and Data Enrichment Improvements:**

* The `VulnsHandler` endpoint now supports returning all active vulnerabilities across all managed plugins and sites if no plugin is specified, and enriches vulnerability data with the list of affected sites. The response structure is improved for frontend consumption and better error handling is introduced.

* The `PluginSite` struct now includes the `SiteName` field, which is populated in `GetCachedPluginData`, allowing for more informative responses regarding which sites are affected by a vulnerability. [[1]](diffhunk://#diff-54b3fd8e2e25ffb6870d3349c58922a87be559357d979837db25b6f1fb95da77R16) [[2]](diffhunk://#diff-51621c42b4aea8d12a426077a555c544019e4658ff8f041572f1fb973c91c406R98-R106) [[3]](diffhunk://#diff-51621c42b4aea8d12a426077a555c544019e4658ff8f041572f1fb973c91c406R127)

**Vulnerability Processing and Reporting Refactoring:**

* The vulnerability processing logic is refactored:  
  - The new `IsVersionAffected` function centralizes version range checks for vulnerabilities.  
  - The new `GetVulnerabilityReportsForPlugin` function generates vulnerability reports for a specific plugin and its sites.  
  - The main `ProcessVulnerabilities` function is simplified to use these helpers, improving readability and maintainability.

* Vulnerability report and plugin data models are extended to include `Slug` and `PluginName` fields, ensuring consistent and descriptive identification of plugins in reports and output. [[1]](diffhunk://#diff-975f48dc36e58a7c1afdfe3a17aa116a76faaf7e4cb8cc94505e2d954cb33eaeR87-R94) [[2]](diffhunk://#diff-975f48dc36e58a7c1afdfe3a17aa116a76faaf7e4cb8cc94505e2d954cb33eaeR67) [[3]](diffhunk://#diff-c2d7f3a2f5fc3e69546f3e94636622dc7ded71790f17754a9902f0316e77b9ccL163-R171)

**Output and Formatting Enhancements:**

* The formatting of vulnerability reports and site summaries now uses the plugin's display name where available, providing more user-friendly output in CLI or logs. [[1]](diffhunk://#diff-c2d7f3a2f5fc3e69546f3e94636622dc7ded71790f17754a9902f0316e77b9ccL276-R292) [[2]](diffhunk://#diff-c2d7f3a2f5fc3e69546f3e94636622dc7ded71790f17754a9902f0316e77b9ccL335-R357)

**Import and Dependency Updates:**

* The `internal/api/data_handlers.go` file now imports the new `internal/vuln` package to leverage the refactored vulnerability logic.