### PR TITLE
fix(fetch): validate plugin slugs before fetching

### DIFF
--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -14,6 +14,7 @@ var (
 	fetchCmd   = &cobra.Command{
 		Use:   "fetch",
 		Short: "Fetch latest data from SpinupWP and update local cache.",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := "basic"
 			if len(args) > 0 {

--- a/internal/fetch/wporg/wporg.go
+++ b/internal/fetch/wporg/wporg.go
@@ -6,12 +6,17 @@ import (
 	"net/http"
 
 	"github.com/JCO-Digital/jman/internal/models"
+	"github.com/JCO-Digital/jman/internal/utils"
 )
 
 const PluginInfoAPIURL = "https://api.wordpress.org/plugins/info/1.0/"
 
 // GetPluginInfo fetches metadata for a single plugin by slug from WordPress.org.
 func GetPluginInfo(slug string) (*models.PluginInfo, error) {
+	if !utils.IsValidSlug(slug) {
+		return nil, nil
+	}
+
 	endpoint := fmt.Sprintf("%s%s.json", PluginInfoAPIURL, slug)
 
 	resp, err := http.Get(endpoint)

--- a/internal/fetch/wpvuln/wpvuln.go
+++ b/internal/fetch/wpvuln/wpvuln.go
@@ -6,12 +6,25 @@ import (
 	"net/http"
 
 	"github.com/JCO-Digital/jman/internal/models"
+	"github.com/JCO-Digital/jman/internal/utils"
 )
 
 const WPVulnerabilityAPIURL = "https://www.wpvulnerability.net/plugin/"
 
 // GetVulnerabilities fetches vulnerability data for a specific WordPress plugin.
 func GetVulnerabilities(pluginName string) (*models.VulnResponse, error) {
+	if !utils.IsValidSlug(pluginName) {
+		msg := "Invalid WordPress plugin slug"
+		return &models.VulnResponse{
+			Error:   1,
+			Message: &msg,
+			Data: &models.VulnData{
+				Plugin:        pluginName,
+				Vulnerability: []models.Vulnerability{},
+			},
+		}, nil
+	}
+
 	endpoint := fmt.Sprintf("%s%s", WPVulnerabilityAPIURL, pluginName)
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)

--- a/internal/fetch/wpvuln/wpvuln.go
+++ b/internal/fetch/wpvuln/wpvuln.go
@@ -16,7 +16,7 @@ func GetVulnerabilities(pluginName string) (*models.VulnResponse, error) {
 	if !utils.IsValidSlug(pluginName) {
 		msg := "Invalid WordPress plugin slug"
 		return &models.VulnResponse{
-			Error:   1,
+			Error:   0,
 			Message: &msg,
 			Data: &models.VulnData{
 				Plugin:        pluginName,

--- a/internal/utils/string.go
+++ b/internal/utils/string.go
@@ -9,6 +9,12 @@ import (
 // htmlTagRegexp matches basic HTML tags for removal in CleanHTML.
 var htmlTagRegexp = regexp.MustCompile(`<[^>]*>`)
 var unifyHyphens = regexp.MustCompile(`[-–—]+`)
+var slugRegex = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// IsValidSlug checks if a plugin slug is valid according to WordPress standards.
+func IsValidSlug(slug string) bool {
+	return slugRegex.MatchString(slug)
+}
 
 // CleanHTML removes HTML tags, decodes HTML entities, and trims surrounding whitespace.
 // This normalizes text from external feeds (like WordPress.org or vulnerability databases)

--- a/internal/utils/string_test.go
+++ b/internal/utils/string_test.go
@@ -104,3 +104,33 @@ func TestShowFirstPart(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidSlug(t *testing.T) {
+	tests := []struct {
+		slug     string
+		expected bool
+	}{
+		{"akismet", true},
+		{"jetpack", true},
+		{"contact-form-7", true},
+		{"wordpress-seo", true},
+		{"woocommerce", true},
+		{"my-plugin-123", true},
+		{"Invalid-Slug", false},
+		{"invalid_slug", false},
+		{"invalid/slug", false},
+		{"invalid.slug", false},
+		{"", false},
+		{"-starting-with-hyphen", true}, // WP allows this usually, though rare
+		{"ending-with-hyphen-", true},   // WP allows this usually, though rare
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.slug, func(t *testing.T) {
+			result := IsValidSlug(tt.slug)
+			if result != tt.expected {
+				t.Errorf("IsValidSlug(%q) = %v, want %v", tt.slug, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add IsValidSlug utility and use it in wporg and wpvuln fetchers to avoid requests for
invalid slugs. For wporg an invalid slug returns nil, for wpvuln an error response with
an empty vulnerability list is returned. Also limit fetch command to a maximum of one
argument and add tests for IsValidSlug