### PR TITLE
fix(wpcli): add --force when installing zip plugins

### DIFF
--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -2,8 +2,11 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/JCO-Digital/jman/internal/cache"
 	"github.com/JCO-Digital/jman/internal/config"
@@ -101,8 +104,38 @@ func pluginCommand(cmd *cobra.Command, args []string) error {
 }
 
 func installPlugin(site models.CliSite, pluginName string) error {
+	installSource := pluginName
+
+	// Check if pluginName is a local ZIP file
+	if strings.HasSuffix(strings.ToLower(pluginName), ".zip") {
+		if info, err := os.Stat(pluginName); err == nil && !info.IsDir() {
+			if site.SSH != "" {
+				// Remote site: upload the file
+				remoteTempPath := fmt.Sprintf("/tmp/jman-%d-%s", time.Now().Unix(), filepath.Base(pluginName))
+				verb.Printf(verb.Verbose, "Uploading %s to %s:%s...\n", pluginName, site.ServerName, remoteTempPath)
+
+				if err := wpcli.UploadFile(site.SSH, pluginName, remoteTempPath); err != nil {
+					return fmt.Errorf("failed to upload plugin: %w", err)
+				}
+
+				installSource = remoteTempPath
+				// Ensure cleanup on the remote server
+				defer func() {
+					verb.Printf(verb.Debug, "Cleaning up remote file %s...\n", remoteTempPath)
+					wpcli.RunSSH(site.SSH, "rm", remoteTempPath)
+				}()
+			} else {
+				// Local site: use absolute path
+				absPath, err := filepath.Abs(pluginName)
+				if err == nil {
+					installSource = absPath
+				}
+			}
+		}
+	}
+
 	verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, verb.Blue(site.Name), verb.Yellow(site.ServerName))
-	success, err := wpcli.AddPlugin(site.SSH, site.Path, pluginName, true)
+	success, err := wpcli.AddPlugin(site.SSH, site.Path, installSource, true)
 	if err != nil {
 		return err
 	}

--- a/internal/wpcli/plugins.go
+++ b/internal/wpcli/plugins.go
@@ -55,6 +55,13 @@ func GetPlugins(site models.CliSite, skipPlugins bool) ([]models.WPPlugin, error
 // AddPlugin installs and optionally activates a plugin.
 func AddPlugin(ssh, path, plugin string, activate bool) (bool, error) {
 	args := []string{"plugin", "install", plugin}
+
+	// If the plugin is a ZIP file (local or URL), add --force to allow updating.
+	lowerPlugin := strings.ToLower(plugin)
+	if strings.HasSuffix(lowerPlugin, ".zip") || strings.Contains(lowerPlugin, ".zip?") {
+		args = append(args, "--force")
+	}
+
 	if activate {
 		args = append(args, "--activate")
 	}

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -112,3 +112,47 @@ func SetDisallowFileMods(ssh, path string, value bool) error {
 	_, err := RunWP(CliOptions{SSH: ssh, Path: path}, "config", "set", "--raw", "DISALLOW_FILE_MODS", valStr)
 	return err
 }
+
+// RunSSH executes an arbitrary command via SSH on the target server.
+func RunSSH(ssh string, args ...string) (RunResult, error) {
+	if ssh == "" {
+		return RunResult{}, fmt.Errorf("ssh connection string is required")
+	}
+
+	cmdArgs := append([]string{ssh}, args...)
+	cmd := exec.Command("ssh", cmdArgs...)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	res := RunResult{
+		Output: outBuf.String(),
+		Error:  errBuf.String(),
+	}
+
+	verb.Printf(verb.Debug, "SSH Command output:\n%s\n\nError output:\n%s", res.Output, res.Error)
+
+	return res, err
+}
+
+// UploadFile transfers a local file to a remote path via SCP.
+func UploadFile(ssh, localPath, remotePath string) error {
+	if ssh == "" {
+		return fmt.Errorf("ssh connection string is required for upload")
+	}
+
+	// Format scp destination: user@host:path
+	destination := fmt.Sprintf("%s:%s", ssh, remotePath)
+	cmd := exec.Command("scp", localPath, destination)
+
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to upload file via scp: %w (stderr: %s)", err, errBuf.String())
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request updates the plugin installation logic to better handle ZIP plugins. Now, when installing a plugin from a ZIP file (either a local file or a URL), the `--force` flag is automatically added to the command, ensuring that updates to existing plugins via ZIP files are supported.

**Plugin installation improvements:**

* [`internal/wpcli/plugins.go`](diffhunk://#diff-f9f25f5994c8026d7668e95920efe391e30685a7e3159b96844a8121daaada6dR58-R64): Modified the `AddPlugin` function to append `--force` when the plugin source ends with `.zip` or contains `.zip?`, allowing ZIP-based plugin updates.