### PR TITLE
Feat/backup

### DIFF
--- a/cmd/jman-api/main.go
+++ b/cmd/jman-api/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/JCO-Digital/jman/internal/api"
+	"github.com/JCO-Digital/jman/internal/backup"
 	"github.com/JCO-Digital/jman/internal/config"
 	"github.com/JCO-Digital/jman/internal/db"
 	"github.com/spf13/cobra"
@@ -55,6 +56,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 			),
 		),
 	)
+
+	// Start the database backup scheduler
+	backup.StartScheduler(cmd.Context())
 
 	log.Printf("Starting jman-api (version: %s) on :%s", config.AppVersion, port)
 	return http.ListenAndServe(":"+port, handler)

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -49,12 +49,13 @@ func StartScheduler(ctx context.Context) {
 // PerformBackup creates a snapshot of the current database using VACUUM INTO.
 // It also manages a symlink to the latest backup and cleans up files older than 48 hours.
 func PerformBackup() error {
+	start := time.Now()
 	// Ensure backup directory exists
 	if err := os.MkdirAll(config.RunData.BackupDir, 0755); err != nil {
 		return fmt.Errorf("failed to create backup directory: %w", err)
 	}
 
-	timestamp := time.Now().Format("20060102-150405")
+	timestamp := start.Format("20060102-150405")
 	backupFileName := fmt.Sprintf("jman-%s.db", timestamp)
 	backupPath := filepath.Join(config.RunData.BackupDir, backupFileName)
 
@@ -75,7 +76,7 @@ func PerformBackup() error {
 		log.Printf("Warning: failed to update 'latest.db' symlink: %v", err)
 	}
 
-	log.Printf("Database backup successful: %s", backupFileName)
+	log.Printf("Database backup successful: %s (took %v)", backupFileName, time.Since(start))
 
 	return cleanupOldBackups()
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,0 +1,125 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/JCO-Digital/jman/internal/config"
+	"github.com/JCO-Digital/jman/internal/db"
+	"github.com/JCO-Digital/jman/internal/slack"
+)
+
+// StartScheduler starts a background goroutine that performs periodic backups.
+// It performs an initial backup immediately and then every hour.
+func StartScheduler(ctx context.Context) {
+	go func() {
+		log.Println("Starting database backup scheduler...")
+
+		// Initial backup on startup
+		if err := PerformBackup(); err != nil {
+			msg := fmt.Sprintf("🚨 Initial database backup failed: %v", err)
+			log.Println(msg)
+			_ = slack.SendMessage(msg, true)
+		}
+
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				if err := PerformBackup(); err != nil {
+					msg := fmt.Sprintf("🚨 Periodic database backup failed: %v", err)
+					log.Println(msg)
+					_ = slack.SendMessage(msg, true)
+				}
+			case <-ctx.Done():
+				log.Println("Database backup scheduler stopped.")
+				return
+			}
+		}
+	}()
+}
+
+// PerformBackup creates a snapshot of the current database using VACUUM INTO.
+// It also manages a symlink to the latest backup and cleans up files older than 48 hours.
+func PerformBackup() error {
+	// Ensure backup directory exists
+	if err := os.MkdirAll(config.RunData.BackupDir, 0755); err != nil {
+		return fmt.Errorf("failed to create backup directory: %w", err)
+	}
+
+	timestamp := time.Now().Format("20060102-150405")
+	backupFileName := fmt.Sprintf("jman-%s.db", timestamp)
+	backupPath := filepath.Join(config.RunData.BackupDir, backupFileName)
+
+	// Perform the backup using the database package
+	if err := db.Backup(backupPath); err != nil {
+		return err
+	}
+
+	// Update the 'latest.db' symlink
+	latestPath := filepath.Join(config.RunData.BackupDir, "latest.db")
+
+	// Remove existing symlink or file if it exists
+	_ = os.Remove(latestPath)
+
+	// Create new symlink pointing to the new backup file.
+	// We use a relative path for the target so the directory remains portable.
+	if err := os.Symlink(backupFileName, latestPath); err != nil {
+		log.Printf("Warning: failed to update 'latest.db' symlink: %v", err)
+	}
+
+	log.Printf("Database backup successful: %s", backupFileName)
+
+	return cleanupOldBackups()
+}
+
+// cleanupOldBackups removes backup files older than 48 hours.
+func cleanupOldBackups() error {
+	files, err := os.ReadDir(config.RunData.BackupDir)
+	if err != nil {
+		return fmt.Errorf("failed to read backup directory for cleanup: %w", err)
+	}
+
+	now := time.Now()
+	retentionPeriod := 48 * time.Hour
+	deletedCount := 0
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		name := file.Name()
+		// Only touch files that match our backup pattern jman-YYYYMMDD-HHMMSS.db
+		if !strings.HasPrefix(name, "jman-") || !strings.HasSuffix(name, ".db") || name == "latest.db" {
+			continue
+		}
+
+		info, err := file.Info()
+		if err != nil {
+			continue
+		}
+
+		if now.Sub(info.ModTime()) > retentionPeriod {
+			path := filepath.Join(config.RunData.BackupDir, name)
+			if err := os.Remove(path); err != nil {
+				log.Printf("Warning: failed to remove old backup %s: %v", name, err)
+			} else {
+				deletedCount++
+			}
+		}
+	}
+
+	if deletedCount > 0 {
+		log.Printf("Cleaned up %d old backup(s)", deletedCount)
+	}
+
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Runtime struct {
 	ConfigDir string
 	CacheDir  string
 	DataDir   string
+	BackupDir string
 	Version   string
 }
 
@@ -50,15 +51,16 @@ func Init() error {
 		ConfigDir: filepath.Join(xdg.ConfigHome, AppName),
 		CacheDir:  filepath.Join(xdg.CacheHome, AppName),
 		DataDir:   filepath.Join(xdg.DataHome, AppName),
+		BackupDir: filepath.Join(xdg.DataHome, AppName, "backups"),
 	}
 
 	// Ensure directories exist.
 	// ConfigDir uses 0700 because it stores secrets (users.toml with JWT/TOTP keys).
-	// CacheDir and DataDir use 0755 as they don't contain secrets.
+	// CacheDir, DataDir and BackupDir use 0755 as they don't contain secrets.
 	if err := os.MkdirAll(RunData.ConfigDir, 0700); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", RunData.ConfigDir, err)
 	}
-	for _, dir := range []string{RunData.CacheDir, RunData.DataDir} {
+	for _, dir := range []string{RunData.CacheDir, RunData.DataDir, RunData.BackupDir} {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", dir, err)
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -82,6 +82,27 @@ func GetDB() *sql.DB {
 	return dbInstance
 }
 
+// Backup creates a snapshot of the database using VACUUM INTO.
+func Backup(destPath string) error {
+	dbMutex.Lock()
+	defer dbMutex.Unlock()
+
+	if dbInstance == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// SQLite's VACUUM INTO requires the target file to NOT exist.
+	// We escape single quotes in the path just in case.
+	escapedPath := strings.ReplaceAll(destPath, "'", "''")
+	query := fmt.Sprintf("VACUUM INTO '%s'", escapedPath)
+
+	if _, err := dbInstance.Exec(query); err != nil {
+		return fmt.Errorf("VACUUM INTO failed: %w", err)
+	}
+
+	return nil
+}
+
 // Close closes the database connection.
 func Close() error {
 	dbMutex.Lock()


### PR DESCRIPTION
This pull request introduces an automated database backup system to the application. The main change is the addition of a background scheduler that periodically creates database snapshots, manages backup files, and cleans up old backups. This improves data safety and operational reliability by ensuring regular backups and easy restoration.

**Automated Database Backups:**

* Added a new `internal/backup/backup.go` module that implements a scheduler to perform database backups immediately on startup and then every hour. It manages a `latest.db` symlink for quick access to the most recent backup and cleans up backups older than 48 hours. Backup failures are logged and reported to Slack.
* The backup scheduler is started during server startup in `cmd/jman-api/main.go`.
* The backup package is imported in the main API entrypoint.

**Configuration and Directory Management:**

* Added a `BackupDir` field to the `config.Runtime` struct and ensured the backup directory is created at startup, with appropriate permissions. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR22) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR54-R63)

**Database Layer Enhancements:**

* Added a `Backup` function to `internal/db/db.go` that uses SQLite's `VACUUM INTO` to create a snapshot of the current database.