### PR TITLE
refactor(db): migrate plugin cache from JSON files to SQLite

### DIFF
--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -14,9 +14,9 @@ import (
 
 // PluginsHandler returns the list of cached WordPress plugins.
 func PluginsHandler(w http.ResponseWriter, r *http.Request) {
-	plugins := []models.WPPlugin{}
-	if err := cache.ReadJSONCache("plugins", &plugins, -1); err != nil {
-		WriteError(w, http.StatusNotFound, fmt.Sprintf("Cache missing: %v", err))
+	plugins, err := db.GetAllSitePlugins()
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, fmt.Sprintf("Database error: %v", err))
 		return
 	}
 

--- a/internal/cache/plugininfo.go
+++ b/internal/cache/plugininfo.go
@@ -2,7 +2,7 @@ package cache
 
 import (
 	"fmt"
-	"os"
+	"sort"
 	"sync"
 	"time"
 
@@ -11,65 +11,9 @@ import (
 	"github.com/JCO-Digital/jman/internal/models"
 	"github.com/JCO-Digital/jman/internal/utils"
 	"github.com/JCO-Digital/jman/internal/verb"
+	"github.com/JCO-Digital/jman/internal/wpcli"
 	"github.com/hashicorp/go-version"
 )
-
-var (
-	migrationOnce sync.Once
-)
-
-// migrateIfNecessary checks if the legacy JSON cache exists and migrates it to SQLite.
-func migrateIfNecessary() {
-	migrationOnce.Do(func() {
-		filename := "plugin_info"
-		legacyPath := getCacheFilePath(filename)
-
-		if _, err := os.Stat(legacyPath); os.IsNotExist(err) {
-			return
-		}
-
-		verb.Printf(verb.Verbose, "Migrating legacy plugin info cache to SQLite...\n")
-
-		cache := &PluginInfoCache{
-			Plugins: make(map[string]PluginInfoEntry),
-		}
-
-		// Read the old JSON file
-		if err := ReadJSONCache(filename, cache, -1); err != nil {
-			verb.PrintErrorf(verb.Verbose, "Warning: failed to read legacy cache for migration: %v\n", err)
-			return
-		}
-
-		// Insert into SQLite
-		count := 0
-		for _, entry := range cache.Plugins {
-			// Note: We can't easily preserve the exact 'FetchedAt' via the simple SavePluginInfo
-			// because it defaults to CURRENT_TIMESTAMP, but for a one-time migration
-			// this is acceptable as it just resets the 24h TTL.
-			info := entry.Info
-			sanitizePluginInfo(&info)
-			if err := db.SavePluginInfo(info); err == nil {
-				count++
-			}
-		}
-
-		verb.Printf(verb.Verbose, "Migrated %d entries. Removing legacy file: %s\n", count, legacyPath)
-
-		// Backup/Remove the old file
-		_ = os.Rename(legacyPath, legacyPath+".bak")
-	})
-}
-
-// PluginInfoCache and PluginInfoEntry are kept for legacy migration support.
-type PluginInfoCache struct {
-	Plugins   map[string]PluginInfoEntry `json:"plugins"`
-	UpdatedAt time.Time                  `json:"updated_at"`
-}
-
-type PluginInfoEntry struct {
-	Info      models.PluginInfo `json:"info"`
-	FetchedAt time.Time         `json:"fetched_at"`
-}
 
 // GetPluginName returns the human-readable name for a plugin slug.
 func GetPluginName(slug string) string {
@@ -80,20 +24,8 @@ func GetPluginName(slug string) string {
 	return slug
 }
 
-// sanitizePluginInfo normalizes fields before writing to DB.
-func sanitizePluginInfo(info *models.PluginInfo) {
-	if info == nil {
-		return
-	}
-
-	info.Name = utils.CleanHTML(info.Name)
-	info.Author = utils.CleanHTML(info.Author)
-}
-
 // UpdatePluginInfo updates or creates a plugin info entry with new data.
 func UpdatePluginInfo(slug, name, ver string, fullFetch ...bool) bool {
-	migrateIfNecessary()
-
 	isFull := false
 	if len(fullFetch) > 0 && fullFetch[0] {
 		isFull = true
@@ -114,14 +46,14 @@ func UpdatePluginInfo(slug, name, ver string, fullFetch ...bool) bool {
 		if info.Name == "" {
 			info.Name = slug
 		}
-		sanitizePluginInfo(info)
+		models.SanitizePluginInfo(info)
 		_ = db.SavePluginInfo(*info)
 		return true
 	}
 
 	updated := false
 	if isFull {
-		sanitizePluginInfo(info)
+		models.SanitizePluginInfo(info)
 		_ = db.SavePluginInfo(*info)
 		return true
 	}
@@ -144,7 +76,7 @@ func UpdatePluginInfo(slug, name, ver string, fullFetch ...bool) bool {
 
 	// Always sanitize to ensure any legacy uncleaned data is fixed.
 	oldName, oldAuthor := existing.Name, existing.Author
-	sanitizePluginInfo(existing)
+	models.SanitizePluginInfo(existing)
 
 	if updated || existing.Name != oldName || existing.Author != oldAuthor {
 		_ = db.SavePluginInfo(*existing)
@@ -157,8 +89,6 @@ func UpdatePluginInfo(slug, name, ver string, fullFetch ...bool) bool {
 // GetPluginInfo returns the full cached PluginInfo for a slug,
 // fetching from the API if stale or missing.
 func GetPluginInfo(slug string, ttl ...time.Duration) *models.PluginInfo {
-	migrateIfNecessary()
-
 	t := DefaultTTL
 	if len(ttl) > 0 {
 		t = ttl[0]
@@ -168,25 +98,50 @@ func GetPluginInfo(slug string, ttl ...time.Duration) *models.PluginInfo {
 	if err == nil && existing != nil && t > 0 && time.Since(fetchedAt) < t {
 		// Ensure data is sanitized even if it's already in the cache.
 		oldName, oldAuthor := existing.Name, existing.Author
-		sanitizePluginInfo(existing)
+		models.SanitizePluginInfo(existing)
 		if existing.Name != oldName || existing.Author != oldAuthor {
 			_ = db.SavePluginInfo(*existing)
 		}
 		return existing
 	}
 
-	// Fetch from API
+	// Skip remote fetches for mu-plugins and dropins as they won't have metadata on WP.org or via 'plugin get'
+	if isSpecialPlugin(slug, nil) {
+		verb.Printf(verb.Verbose, "Skipping remote metadata fetch for special plugin (mu/dropin): %s\n", slug)
+		return existing
+	}
+
+	// Fetch from API (WordPress.org)
+	verb.Printf(verb.Verbose, "Fetching metadata for %s from WordPress.org...\n", slug)
 	info, err := wporg.GetPluginInfo(slug)
 	if err != nil {
-		verb.PrintErrorf(verb.Verbose, "Warning: failed to fetch plugin info for %s: %v\n", slug, err)
-		return existing // Fallback to stale
+		verb.PrintErrorf(verb.Verbose, "Warning: failed to fetch plugin info for %s from WordPress.org: %v\n", slug, err)
+	} else if info != nil {
+		verb.Printf(verb.Verbose, "Successfully fetched metadata for %s from WordPress.org.\n", slug)
+	}
+
+	// Fallback to WP-CLI if not found on WP.org
+	if info == nil {
+		verb.Printf(verb.Verbose, "Plugin %s not found on WordPress.org, trying WP-CLI...\n", slug)
+
+		// Pre-fetch site list for fallback
+		sites, _ := GetSiteList()
+		siteMap := make(map[int]models.CliSite)
+		for _, s := range sites {
+			siteMap[s.ID] = s
+		}
+
+		info, err = fetchPluginInfoFromSites(slug, siteMap, nil)
+		if err != nil {
+			verb.PrintErrorf(verb.Verbose, "WP-CLI fallback failed for %s: %v\n", slug, err)
+		}
 	}
 
 	if info == nil {
 		return existing
 	}
 
-	sanitizePluginInfo(info)
+	models.SanitizePluginInfo(info)
 	if err := db.SavePluginInfo(*info); err != nil {
 		verb.PrintErrorf(verb.Verbose, "Warning: failed to save plugin info for %s: %v\n", slug, err)
 	}
@@ -196,11 +151,39 @@ func GetPluginInfo(slug string, ttl ...time.Duration) *models.PluginInfo {
 
 // RefreshPluginInfoCache fetches info for all given slugs concurrently.
 func RefreshPluginInfoCache(slugs []string, ttl ...time.Duration) error {
-	migrateIfNecessary()
-
 	t := DefaultTTL
 	if len(ttl) > 0 {
 		t = ttl[0]
+	}
+
+	// Pre-fetch site list once to avoid redundant cache/DB hits in the fallback loop.
+	sites, _ := GetSiteList()
+	siteMap := make(map[int]models.CliSite)
+	for _, s := range sites {
+		siteMap[s.ID] = s
+	}
+
+	// Pre-fetch all site plugins to avoid thousands of DB queries.
+	allPlugins, _ := db.GetAllSitePlugins()
+	pluginToSites := make(map[string][]int)
+	isSpecial := make(map[string]bool)
+	isRegular := make(map[string]bool)
+
+	for _, p := range allPlugins {
+		if p.Status == "must-use" || p.Status == "dropin" {
+			isSpecial[p.Name] = true
+		} else {
+			isRegular[p.Name] = true
+			pluginToSites[p.Name] = append(pluginToSites[p.Name], p.SiteID)
+		}
+	}
+
+	// A plugin is considered "special" (mu/dropin) only if it doesn't exist as a regular plugin anywhere.
+	specialOnlyMap := make(map[string]bool)
+	for slug := range isSpecial {
+		if !isRegular[slug] {
+			specialOnlyMap[slug] = true
+		}
 	}
 
 	var wg sync.WaitGroup
@@ -211,7 +194,7 @@ func RefreshPluginInfoCache(slugs []string, ttl ...time.Duration) error {
 		if err == nil && !fetchedAt.IsZero() && t > 0 && time.Since(fetchedAt) < t {
 			if existing != nil {
 				oldName, oldAuthor := existing.Name, existing.Author
-				sanitizePluginInfo(existing)
+				models.SanitizePluginInfo(existing)
 				if existing.Name != oldName || existing.Author != oldAuthor {
 					_ = db.SavePluginInfo(*existing)
 				}
@@ -220,22 +203,110 @@ func RefreshPluginInfoCache(slugs []string, ttl ...time.Duration) error {
 		}
 
 		slug := slug
-		wg.Go(func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			info, err := wporg.GetPluginInfo(slug)
-			if err != nil || info == nil {
+			if isSpecialPlugin(slug, specialOnlyMap) {
 				return
 			}
 
-			sanitizePluginInfo(info)
+			verb.Printf(verb.Verbose, "Fetching metadata for %s from WordPress.org...\n", slug)
+			info, err := wporg.GetPluginInfo(slug)
+			if err != nil {
+				verb.PrintErrorf(verb.Verbose, "Warning: failed to fetch plugin info for %s from WordPress.org: %v\n", slug, err)
+			}
+
+			if info == nil {
+				verb.Printf(verb.Verbose, "Plugin %s not found on WordPress.org, trying WP-CLI fallback...\n", slug)
+				info, err = fetchPluginInfoFromSites(slug, siteMap, pluginToSites)
+				if err != nil {
+					verb.PrintErrorf(verb.Verbose, "WP-CLI fallback failed for %s: %v\n", slug, err)
+				}
+			}
+
+			if info != nil {
+				verb.Printf(verb.Verbose, "Successfully fetched metadata for %s.\n", slug)
+			}
+
+			if info == nil {
+				return
+			}
+
+			models.SanitizePluginInfo(info)
 			_ = db.SavePluginInfo(*info)
-		})
+		}()
 	}
 
 	wg.Wait()
 	return nil
+}
+
+func isSpecialPlugin(slug string, specialOnlyMap map[string]bool) bool {
+	if specialOnlyMap != nil {
+		return specialOnlyMap[slug]
+	}
+
+	// If it's found as a regular plugin anywhere, we don't treat it as special for fetching purposes.
+	siteIDs, _ := db.GetSitesWithPlugin(slug)
+	if len(siteIDs) > 0 {
+		return false
+	}
+
+	dbConn := db.GetDB()
+	if dbConn == nil {
+		return false
+	}
+
+	var exists bool
+	query := "SELECT EXISTS(SELECT 1 FROM site_plugins WHERE slug = ? AND (status = 'must-use' OR status = 'dropin'))"
+	_ = dbConn.QueryRow(query, slug).Scan(&exists)
+	return exists
+}
+
+// fetchPluginInfoFromSites attempts to get plugin metadata from a site where it is installed.
+func fetchPluginInfoFromSites(slug string, siteMap map[int]models.CliSite, pluginToSites map[string][]int) (*models.PluginInfo, error) {
+	var siteIDs []int
+	var err error
+
+	if pluginToSites != nil {
+		siteIDs = pluginToSites[slug]
+	} else {
+		siteIDs, err = db.GetSitesWithPlugin(slug)
+	}
+
+	if err != nil || len(siteIDs) == 0 {
+		return nil, err
+	}
+
+	// Sort site IDs by failure count to prioritize healthier sites.
+	sort.Slice(siteIDs, func(i, j int) bool {
+		return wpcli.GetFailureCount(siteIDs[i]) < wpcli.GetFailureCount(siteIDs[j])
+	})
+
+	for _, id := range siteIDs {
+		site, ok := siteMap[id]
+		if !ok {
+			continue
+		}
+
+		// Only attempt sites that haven't failed too many times recently.
+		if wpcli.GetFailureCount(id) > 3 {
+			continue
+		}
+
+		verb.Printf(verb.Verbose, "Attempting WP-CLI fetch for %s from site %s...\n", slug, site.Name)
+		info, err := wpcli.GetPluginInfo(site, slug, 15*time.Second)
+		if err == nil && info != nil {
+			verb.Printf(verb.Verbose, "Successfully fetched metadata for %s from site %s.\n", slug, site.Name)
+			return info, nil
+		}
+		verb.PrintErrorf(verb.Verbose, "Failed to fetch metadata for %s from site %s: %v\n", slug, site.Name, err)
+	}
+
+	return nil, fmt.Errorf("plugin info not found on any site")
 }
 
 func DisplayPluginName(slug string, truncate, color bool) string {

--- a/internal/cache/plugininfo.go
+++ b/internal/cache/plugininfo.go
@@ -106,7 +106,10 @@ func GetPluginInfo(slug string, ttl ...time.Duration) *models.PluginInfo {
 	}
 
 	// Skip remote fetches for mu-plugins and dropins as they won't have metadata on WP.org or via 'plugin get'
-	if isSpecialPlugin(slug, nil) {
+	special, err := isSpecialPlugin(slug, nil)
+	if err != nil {
+		verb.PrintErrorf(verb.Verbose, "Warning: failed to check if plugin %s is special: %v\n", slug, err)
+	} else if special {
 		verb.Printf(verb.Verbose, "Skipping remote metadata fetch for special plugin (mu/dropin): %s\n", slug)
 		return existing
 	}
@@ -125,7 +128,11 @@ func GetPluginInfo(slug string, ttl ...time.Duration) *models.PluginInfo {
 		verb.Printf(verb.Verbose, "Plugin %s not found on WordPress.org, trying WP-CLI...\n", slug)
 
 		// Pre-fetch site list for fallback
-		sites, _ := GetSiteList()
+		sites, err := GetSiteList()
+		if err != nil {
+			verb.PrintErrorf(verb.Verbose, "Warning: failed to get site list for WP-CLI fallback: %v\n", err)
+			return existing
+		}
 		siteMap := make(map[int]models.CliSite)
 		for _, s := range sites {
 			siteMap[s.ID] = s
@@ -157,7 +164,10 @@ func RefreshPluginInfoCache(slugs []string, ttl ...time.Duration) error {
 	}
 
 	// Pre-fetch site list once to avoid redundant cache/DB hits in the fallback loop.
-	sites, _ := GetSiteList()
+	sites, err := GetSiteList()
+	if err != nil {
+		return fmt.Errorf("failed to get site list for refresh: %w", err)
+	}
 	siteMap := make(map[int]models.CliSite)
 	for _, s := range sites {
 		siteMap[s.ID] = s
@@ -209,7 +219,10 @@ func RefreshPluginInfoCache(slugs []string, ttl ...time.Duration) error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			if isSpecialPlugin(slug, specialOnlyMap) {
+			special, err := isSpecialPlugin(slug, specialOnlyMap)
+			if err != nil {
+				verb.PrintErrorf(verb.Verbose, "Warning: failed to check if plugin %s is special: %v\n", slug, err)
+			} else if special {
 				return
 			}
 
@@ -244,26 +257,32 @@ func RefreshPluginInfoCache(slugs []string, ttl ...time.Duration) error {
 	return nil
 }
 
-func isSpecialPlugin(slug string, specialOnlyMap map[string]bool) bool {
+func isSpecialPlugin(slug string, specialOnlyMap map[string]bool) (bool, error) {
 	if specialOnlyMap != nil {
-		return specialOnlyMap[slug]
+		return specialOnlyMap[slug], nil
 	}
 
 	// If it's found as a regular plugin anywhere, we don't treat it as special for fetching purposes.
-	siteIDs, _ := db.GetSitesWithPlugin(slug)
+	siteIDs, err := db.GetSitesWithPlugin(slug)
+	if err != nil {
+		return false, fmt.Errorf("failed to check sites for plugin %s: %w", slug, err)
+	}
 	if len(siteIDs) > 0 {
-		return false
+		return false, nil
 	}
 
 	dbConn := db.GetDB()
 	if dbConn == nil {
-		return false
+		return false, fmt.Errorf("database not initialized")
 	}
 
 	var exists bool
 	query := "SELECT EXISTS(SELECT 1 FROM site_plugins WHERE slug = ? AND (status = 'must-use' OR status = 'dropin'))"
-	_ = dbConn.QueryRow(query, slug).Scan(&exists)
-	return exists
+	err = dbConn.QueryRow(query, slug).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to query special status for %s: %w", slug, err)
+	}
+	return exists, nil
 }
 
 // fetchPluginInfoFromSites attempts to get plugin metadata from a site where it is installed.

--- a/internal/cache/plugininfo_test.go
+++ b/internal/cache/plugininfo_test.go
@@ -13,7 +13,7 @@ func TestSanitizePluginInfo_DecodesNameAndStripsAuthorHTML(t *testing.T) {
 		Author: "<a href='https://example.com'>Jane &amp; Co</a>",
 	}
 
-	sanitizePluginInfo(info)
+	models.SanitizePluginInfo(info)
 
 	if got, want := info.Name, "My Plugin - Lite"; got != want {
 		t.Fatalf("unexpected sanitized name: got %q, want %q", got, want)
@@ -31,7 +31,7 @@ func TestSanitizePluginInfo_TrimWhitespace(t *testing.T) {
 		Author: "  <strong> ACME&nbsp;Inc </strong>  ",
 	}
 
-	sanitizePluginInfo(info)
+	models.SanitizePluginInfo(info)
 
 	if got, want := info.Name, "Plugin Name"; got != want { // contains NBSP
 		t.Fatalf("unexpected trimmed/decoded name: got %q, want %q", got, want)
@@ -44,5 +44,5 @@ func TestSanitizePluginInfo_TrimWhitespace(t *testing.T) {
 
 func TestSanitizePluginInfo_NilIsNoop(t *testing.T) {
 	// Should not panic.
-	sanitizePluginInfo(nil)
+	models.SanitizePluginInfo(nil)
 }

--- a/internal/cache/plugins.go
+++ b/internal/cache/plugins.go
@@ -5,59 +5,56 @@ import (
 	"sync"
 	"time"
 
+	"github.com/JCO-Digital/jman/internal/db"
 	"github.com/JCO-Digital/jman/internal/fetch/wpvuln"
 	"github.com/JCO-Digital/jman/internal/models"
 	"github.com/JCO-Digital/jman/internal/verb"
 	"github.com/JCO-Digital/jman/internal/wpcli"
 )
 
-var pluginsMu sync.Mutex
-
 // GetCachedPlugins retrieves all installed plugins across all cached sites.
+// It uses the database as the primary cache and fetches from sites if data is missing or forced.
 func GetCachedPlugins(ttl ...time.Duration) ([]models.WPPlugin, error) {
 	t := DefaultTTL
 	if len(ttl) > 0 {
 		t = ttl[0]
 	}
 
-	plugins := []models.WPPlugin{}
-
 	force := t == 0
-	if !force {
-		pluginsMu.Lock()
-		_ = ReadJSONCache("plugins", &plugins, t)
-		pluginsMu.Unlock()
+
+	existingPlugins, err := db.GetAllSitePlugins()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get existing plugins from database: %w", err)
+	}
+
+	hasPlugins := make(map[int]bool)
+	for _, p := range existingPlugins {
+		hasPlugins[p.SiteID] = true
 	}
 
 	sites, err := GetSiteList()
 	if err != nil {
-		return plugins, fmt.Errorf("failed to get site list: %w", err)
+		return existingPlugins, fmt.Errorf("failed to get site list: %w", err)
 	}
 
-	updated := false
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 12)
+	updated := false
+	var mu sync.Mutex
 
 	for _, site := range sites {
-		pluginsMu.Lock()
-		// Skip if we already have plugins for this site
-		siteHasPlugins := false
-		for _, p := range plugins {
-			if p.SiteID == site.ID {
-				siteHasPlugins = true
-				break
-			}
-		}
-		pluginsMu.Unlock()
-
-		if siteHasPlugins && !force {
+		// Skip sites that already have cached plugins unless forcing a refresh.
+		if hasPlugins[site.ID] && !force {
 			continue
 		}
 
 		site := site
-		wg.Go(func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
+
 			sitePlugins, err := wpcli.GetPlugins(site, true)
 			if err != nil {
 				verb.PrintErrorf(verb.Normal, "Warning: failed to fetch plugins for site %s:\n%v\n", verb.Blue(site.Name), verb.Red(err))
@@ -65,35 +62,38 @@ func GetCachedPlugins(ttl ...time.Duration) ([]models.WPPlugin, error) {
 			}
 			verb.Printf(verb.Verbose, "Fetched %d plugins for site %s\n", len(sitePlugins), verb.Blue(site.Name))
 
-			pluginsMu.Lock()
-			plugins = append(plugins, sitePlugins...)
+			// Clear old entries and save new ones for this site.
+			_ = db.DeleteSitePlugins(site.ID)
+			for _, p := range sitePlugins {
+				_ = db.SaveSitePlugin(p)
+
+				if p.Status == "must-use" || p.Status == "dropin" {
+					continue
+				}
+
+				// Incrementally update plugin metadata cache (slug/name/version).
+				bestVer := p.Version
+				if p.Update != "" {
+					bestVer = p.Update
+				}
+				UpdatePluginInfo(p.Name, "", bestVer)
+			}
+
+			mu.Lock()
 			updated = true
-			pluginsMu.Unlock()
-		})
+			mu.Unlock()
+		}()
 	}
 
 	wg.Wait()
 
-	for _, p := range plugins {
-		bestVer := p.Version
-		if p.Update != "" {
-			bestVer = p.Update
-		}
-		UpdatePluginInfo(p.Name, "", bestVer)
-	}
-
 	if updated {
-		pluginsMu.Lock()
-		if err := WriteJSONCache("plugins", plugins); err != nil {
-			verb.PrintErrorf(verb.Normal, "Warning: failed to write plugins cache: %v\n", err)
-		}
-		pluginsMu.Unlock()
+		return db.GetAllSitePlugins()
 	}
-
-	return plugins, nil
+	return existingPlugins, nil
 }
 
-// UpdateSitePluginCache fetches current plugins for a specific site and updates the cache.
+// UpdateSitePluginCache fetches current plugins for a specific site and updates the database.
 func UpdateSitePluginCache(site models.CliSite) error {
 	sitePlugins, err := wpcli.GetPlugins(site, true)
 	if err != nil {
@@ -102,22 +102,20 @@ func UpdateSitePluginCache(site models.CliSite) error {
 
 	verb.Printf(verb.Verbose, "Fetched %d plugins for site %s to update cache\n", len(sitePlugins), verb.Blue(site.Name))
 
-	pluginsMu.Lock()
-	defer pluginsMu.Unlock()
-
-	plugins := []models.WPPlugin{}
-	_ = ReadJSONCache("plugins", &plugins, -1) // Load existing even if expired
-
-	// Filter out old entries for this site and replace with new ones
-	var updatedPlugins []models.WPPlugin
-	for _, p := range plugins {
-		if p.SiteID != site.ID {
-			updatedPlugins = append(updatedPlugins, p)
-		}
+	// Refresh the database records for this site.
+	if err := db.DeleteSitePlugins(site.ID); err != nil {
+		return fmt.Errorf("failed to clear site plugins for %s: %w", site.Name, err)
 	}
-	updatedPlugins = append(updatedPlugins, sitePlugins...)
 
 	for _, p := range sitePlugins {
+		if err := db.SaveSitePlugin(p); err != nil {
+			verb.PrintErrorf(verb.Verbose, "Warning: failed to save plugin %s for site %s: %v\n", p.Name, site.Name, err)
+		}
+
+		if p.Status == "must-use" || p.Status == "dropin" {
+			continue
+		}
+
 		bestVer := p.Version
 		if p.Update != "" {
 			bestVer = p.Update
@@ -125,11 +123,7 @@ func UpdateSitePluginCache(site models.CliSite) error {
 		UpdatePluginInfo(p.Name, "", bestVer)
 	}
 
-	if err := WriteJSONCache("plugins", updatedPlugins); err != nil {
-		return fmt.Errorf("failed to write plugins cache: %w", err)
-	}
-
-	verb.Printf(verb.Verbose, "Cache updated for site %s\n", verb.Blue(site.Name))
+	verb.Printf(verb.Verbose, "Cache updated in database for site %s\n", verb.Blue(site.Name))
 	return nil
 }
 
@@ -140,16 +134,31 @@ func GetCachedPluginData() ([]models.WPPluginData, error) {
 		return []models.WPPluginData{}, err
 	}
 
+	return groupPlugins(plugins)
+}
+
+// GetFastCachedPluginData retrieves plugin data from the database without checking expiry or re-fetching.
+func GetFastCachedPluginData() ([]models.WPPluginData, error) {
+	plugins, err := db.GetAllSitePlugins()
+	if err != nil {
+		return []models.WPPluginData{}, err
+	}
+
+	return groupPlugins(plugins)
+}
+
+// groupPlugins is a internal helper to aggregate a flat plugin list into sites grouped by plugin.
+func groupPlugins(plugins []models.WPPlugin) ([]models.WPPluginData, error) {
 	sites, err := GetSiteList()
 	if err != nil {
-		return []models.WPPluginData{}, err
+		return []models.WPPluginData{}, fmt.Errorf("failed to get site list for grouping: %w", err)
 	}
+
 	siteNames := make(map[int]string)
 	for _, s := range sites {
 		siteNames[s.ID] = s.Name
 	}
 
-	pluginData := []models.WPPluginData{}
 	pluginMap := make(map[string]*models.WPPluginData)
 
 	for _, plugin := range plugins {
@@ -174,6 +183,7 @@ func GetCachedPluginData() ([]models.WPPluginData, error) {
 		})
 	}
 
+	pluginData := make([]models.WPPluginData, 0, len(pluginMap))
 	for _, data := range pluginMap {
 		pluginData = append(pluginData, *data)
 	}
@@ -181,69 +191,18 @@ func GetCachedPluginData() ([]models.WPPluginData, error) {
 	return pluginData, nil
 }
 
-// GetFastCachedPluginData retrieves plugin data from cache without checking expiry.
-func GetFastCachedPluginData() ([]models.WPPluginData, error) {
-	plugins, err := GetFastCachedPlugins()
-	if err != nil {
-		return []models.WPPluginData{}, err
-	}
-
-	sites, err := GetFastSiteList()
-	if err != nil {
-		return []models.WPPluginData{}, err
-	}
-
-	siteNames := make(map[int]string)
-	for _, s := range sites {
-		siteNames[s.ID] = s.Name
-	}
-
-	pluginData := []models.WPPluginData{}
-	pluginMap := make(map[string]*models.WPPluginData)
-
-	for _, plugin := range plugins {
-		if plugin.Status != "active" {
-			continue
-		}
-
-		data, exists := pluginMap[plugin.Name]
-		if !exists {
-			newData := models.WPPluginData{
-				Name:  plugin.Name,
-				Sites: []models.PluginSite{},
-			}
-			pluginMap[plugin.Name] = &newData
-			data = &newData
-		}
-
-		data.Sites = append(data.Sites, models.PluginSite{
-			SiteID:   plugin.SiteID,
-			SiteName: siteNames[plugin.SiteID],
-			Version:  plugin.Version,
-		})
-	}
-
-	for _, data := range pluginMap {
-		pluginData = append(pluginData, *data)
-	}
-
-	return pluginData, nil
-}
-
-// GetFastCachedPlugins retrieves plugins from the cache without checking expiry.
+// GetFastCachedPlugins retrieves plugins from the database without checking expiry.
 func GetFastCachedPlugins() ([]models.WPPlugin, error) {
-	pluginsMu.Lock()
-	defer pluginsMu.Unlock()
-
-	plugins := []models.WPPlugin{}
-	if err := ReadJSONCache("plugins", &plugins, -1); err != nil {
-		return plugins, err
-	}
-	return plugins, nil
+	return db.GetAllSitePlugins()
 }
 
 // GetCachedVulnerabilities fetches vulnerability data for a specific plugin from the cache or the WPVulnerability API.
+// Note: This still uses JSON files for individual plugin vulnerabilities.
 func GetCachedVulnerabilities(plugin string, ttl ...time.Duration) (*models.VulnResponse, error) {
+	if isSpecialPlugin(plugin, nil) {
+		return nil, nil
+	}
+
 	t := DefaultTTL
 	if len(ttl) > 0 {
 		t = ttl[0]

--- a/internal/cache/plugins.go
+++ b/internal/cache/plugins.go
@@ -199,7 +199,10 @@ func GetFastCachedPlugins() ([]models.WPPlugin, error) {
 // GetCachedVulnerabilities fetches vulnerability data for a specific plugin from the cache or the WPVulnerability API.
 // Note: This still uses JSON files for individual plugin vulnerabilities.
 func GetCachedVulnerabilities(plugin string, ttl ...time.Duration) (*models.VulnResponse, error) {
-	if isSpecialPlugin(plugin, nil) {
+	special, err := isSpecialPlugin(plugin, nil)
+	if err != nil {
+		verb.PrintErrorf(verb.Verbose, "Warning: failed to check if plugin %s is special: %v\n", plugin, err)
+	} else if special {
 		return nil, nil
 	}
 

--- a/internal/commands/core.go
+++ b/internal/commands/core.go
@@ -55,13 +55,13 @@ func coreCommand(cmd *cobra.Command, args []string) error {
 		updated := 0
 		for _, site := range sites {
 			verb.Printf(verb.Verbose, "Checking WordPress core on %s...\n", site.Name)
-			coreUpdates, err := wpcli.CheckCore(site.SSH, site.Path)
+			coreUpdates, err := wpcli.CheckCore(site)
 			if err != nil {
 				verb.PrintErrorf(verb.Normal, "Error checking core on %s: %v\n", site.Name, err)
 				continue
 			}
 			if len(coreUpdates) > 0 {
-				currentVersion, err := wpcli.CoreVersion(site.SSH, site.Path)
+				currentVersion, err := wpcli.CoreVersion(site)
 				if err != nil {
 					verb.PrintErrorf(verb.Normal, "Error getting current core version on %s: %v\n", site.Name, err)
 					continue
@@ -90,7 +90,7 @@ func coreCommand(cmd *cobra.Command, args []string) error {
 		updated := 0
 		for _, site := range sites {
 			verb.Printf(verb.Verbose, "Updating WordPress core on %s...\n", site.Name)
-			result, err := wpcli.UpdateCore(site.SSH, site.Path)
+			result, err := wpcli.UpdateCore(site)
 			if err != nil {
 				verb.PrintErrorf(verb.Normal, "Error updating core on %s: %v\n", site.Name, err)
 				continue
@@ -106,7 +106,7 @@ func coreCommand(cmd *cobra.Command, args []string) error {
 	case "version":
 		for _, site := range sites {
 			verb.Printf(verb.Verbose, "Showing WordPress core version on %s...\n", site.Name)
-			version, err := wpcli.CoreVersion(site.SSH, site.Path)
+			version, err := wpcli.CoreVersion(site)
 			if err != nil {
 				verb.PrintErrorf(verb.Normal, "Error showing core version on %s: %v\n", site.Name, err)
 				continue

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -102,6 +102,10 @@ var (
 							continue
 						}
 
+						if response == nil {
+							continue
+						}
+
 						if response.Error != 0 {
 							msg := "unknown error"
 							if response.Message != nil {

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -315,7 +315,7 @@ func installPlugin(site models.CliSite, pluginName string) error {
 	}
 
 	verb.Printf(verb.Verbose, "Installing '%s' on %s (%s)...\n", pluginName, verb.Blue(site.Name), verb.Yellow(site.ServerName))
-	success, err := wpcli.AddPlugin(site.SSH, site.Path, installSource, true)
+	success, err := wpcli.AddPlugin(site, installSource, true)
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func updatePlugin(site models.CliSite, pluginName string) ([]wpcli.UpdateResult,
 	var failed []string
 	var allUpdated []wpcli.UpdateResult
 	for _, p := range toUpdate {
-		results, err := wpcli.UpdatePlugin(site.SSH, site.Path, []string{p})
+		results, err := wpcli.UpdatePlugin(site, []string{p})
 		if err != nil {
 			failed = append(failed, p)
 		} else {
@@ -437,7 +437,7 @@ func getPluginUpdates(site models.CliSite) ([]models.WPPlugin, error) {
 
 func removePlugin(site models.CliSite, pluginName string) error {
 	verb.Printf(verb.Verbose, "Removing '%s' from %s (%s)...\n", verb.Yellow(pluginName), verb.Blue(site.Name), site.ServerName)
-	success, err := wpcli.RemovePlugin(site.SSH, site.Path, pluginName)
+	success, err := wpcli.RemovePlugin(site, pluginName)
 	if err != nil {
 		if strings.Contains(err.Error(), "plugin could not be found") {
 			return fmt.Errorf("plugin not found")
@@ -455,7 +455,7 @@ func removePlugin(site models.CliSite, pluginName string) error {
 
 func pluginInfo(site models.CliSite, pluginName string) error {
 	verb.Printf(verb.Verbose, "Fetching info for '%s' on %s (%s)...\n", verb.Yellow(pluginName), verb.Blue(site.Name), site.ServerName)
-	info, err := wpcli.GetPluginInfo(site.SSH, site.Path, pluginName)
+	info, err := wpcli.GetPluginInfo(site, pluginName)
 	if err != nil {
 		return err
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -20,8 +20,9 @@ var (
 
 // TableDefinition represents the desired state of a database table.
 type TableDefinition struct {
-	Name    string
-	Columns map[string]string // Column name -> SQL type and constraints
+	Name       string
+	Columns    map[string]string // Column name -> SQL type and constraints
+	PrimaryKey []string          // Optional composite primary key
 }
 
 // Init initializes the SQLite database.
@@ -137,14 +138,15 @@ func initSchema() error {
 		{
 			Name: "site_plugins",
 			Columns: map[string]string{
-				"site_id":          "INTEGER",
-				"slug":             "TEXT",
+				"site_id":          "INTEGER NOT NULL",
+				"slug":             "TEXT NOT NULL",
 				"status":           "TEXT",
 				"version":          "TEXT",
 				"update_available": "TEXT",
 				"auto_update":      "BOOLEAN",
 				"updated_at":       "DATETIME DEFAULT CURRENT_TIMESTAMP",
 			},
+			PrimaryKey: []string{"site_id", "slug"},
 		},
 		{
 			Name: "slack_messages",
@@ -237,10 +239,11 @@ func initSchema() error {
 			Name: "site_organization_map",
 			Columns: map[string]string{
 				"site_id":         "INTEGER NOT NULL",
-				"organization_id": "INTEGER REFERENCES organizations(id) ON DELETE CASCADE",
+				"organization_id": "INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE",
 				"created_at":      "DATETIME DEFAULT CURRENT_TIMESTAMP",
 				"created_by":      "TEXT",
 			},
+			PrimaryKey: []string{"site_id", "organization_id"},
 		},
 		{
 			Name: "assets",
@@ -316,14 +319,7 @@ func initSchema() error {
 	if err != nil {
 		return err
 	}
-	_, err = dbInstance.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_site_organization_map ON site_organization_map(site_id, organization_id);")
-	if err != nil {
-		return err
-	}
-	_, err = dbInstance.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_site_plugins_pk ON site_plugins(site_id, slug);")
-	if err != nil {
-		return err
-	}
+
 	_, err = dbInstance.Exec("CREATE INDEX IF NOT EXISTS idx_contacts_organization_id ON contacts(organization_id);")
 	if err != nil {
 		return err
@@ -385,6 +381,9 @@ func migrateTable(def TableDefinition) error {
 	for _, name := range colNames {
 		newColsList = append(newColsList, fmt.Sprintf("%s %s", name, def.Columns[name]))
 	}
+	if len(def.PrimaryKey) > 0 {
+		newColsList = append(newColsList, fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(def.PrimaryKey, ", ")))
+	}
 	newColsSQL := strings.Join(newColsList, ", ")
 
 	if !exists {
@@ -402,7 +401,8 @@ func migrateTable(def TableDefinition) error {
 	}
 	defer rows.Close()
 
-	currentCols := make(map[string]bool)
+	currentCols := make(map[string]int) // name -> notnull
+	currentPK := make(map[string]int)   // name -> pk index
 	for rows.Next() {
 		var cid int
 		var name, typeName string
@@ -411,18 +411,42 @@ func migrateTable(def TableDefinition) error {
 		if err := rows.Scan(&cid, &name, &typeName, &notnull, &dfltValue, &pk); err != nil {
 			return err
 		}
-		currentCols[name] = true
+		currentCols[name] = notnull
+		if pk > 0 {
+			currentPK[name] = pk
+		}
 	}
 
-	// 3. Determine if migration is needed (missing or extra columns)
+	// 3. Determine if migration is needed (missing or extra columns, or NOT NULL change)
 	needsMigration := false
 	if len(currentCols) != len(def.Columns) {
 		needsMigration = true
 	} else {
-		for name := range def.Columns {
-			if !currentCols[name] {
+		for name, colDef := range def.Columns {
+			notnull, exists := currentCols[name]
+			if !exists {
 				needsMigration = true
 				break
+			}
+			// Check for NOT NULL change. PRIMARY KEY also implies NOT NULL in many SQLite versions.
+			expectNotNull := strings.Contains(strings.ToUpper(colDef), "NOT NULL") || strings.Contains(strings.ToUpper(colDef), "PRIMARY KEY")
+			if (notnull == 1) != expectNotNull {
+				needsMigration = true
+				break
+			}
+		}
+	}
+
+	// Check Primary Key change
+	if !needsMigration && len(def.PrimaryKey) > 0 {
+		if len(def.PrimaryKey) != len(currentPK) {
+			needsMigration = true
+		} else {
+			for i, pkCol := range def.PrimaryKey {
+				if currentPK[pkCol] != i+1 {
+					needsMigration = true
+					break
+				}
 			}
 		}
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -135,6 +135,18 @@ func initSchema() error {
 			},
 		},
 		{
+			Name: "site_plugins",
+			Columns: map[string]string{
+				"site_id":          "INTEGER",
+				"slug":             "TEXT",
+				"status":           "TEXT",
+				"version":          "TEXT",
+				"update_available": "TEXT",
+				"auto_update":      "BOOLEAN",
+				"updated_at":       "DATETIME DEFAULT CURRENT_TIMESTAMP",
+			},
+		},
+		{
 			Name: "slack_messages",
 			Columns: map[string]string{
 				"hash":      "TEXT PRIMARY KEY",
@@ -305,6 +317,10 @@ func initSchema() error {
 		return err
 	}
 	_, err = dbInstance.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_site_organization_map ON site_organization_map(site_id, organization_id);")
+	if err != nil {
+		return err
+	}
+	_, err = dbInstance.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_site_plugins_pk ON site_plugins(site_id, slug);")
 	if err != nil {
 		return err
 	}

--- a/internal/db/site_plugins.go
+++ b/internal/db/site_plugins.go
@@ -1,0 +1,158 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/JCO-Digital/jman/internal/models"
+)
+
+// SaveSitePlugin inserts or updates a plugin record for a specific site.
+func SaveSitePlugin(plugin models.WPPlugin) error {
+	db := GetDB()
+	if db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	query := `
+	INSERT INTO site_plugins (
+		site_id, slug, status, version, update_available, auto_update, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	ON CONFLICT(site_id, slug) DO UPDATE SET
+		status = excluded.status,
+		version = excluded.version,
+		update_available = excluded.update_available,
+		auto_update = excluded.auto_update,
+		updated_at = CURRENT_TIMESTAMP;
+	`
+
+	_, err := db.Exec(query,
+		plugin.SiteID,
+		plugin.Name, // WPPlugin.Name is used as the slug
+		plugin.Status,
+		plugin.Version,
+		plugin.Update,
+		plugin.AutoUpdate,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to save site plugin %s for site %d: %w", plugin.Name, plugin.SiteID, err)
+	}
+
+	return nil
+}
+
+// GetSitePlugins retrieves all plugins installed on a specific site.
+func GetSitePlugins(siteID int) ([]models.WPPlugin, error) {
+	db := GetDB()
+	if db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := `
+	SELECT site_id, slug, status, version, update_available, auto_update
+	FROM site_plugins
+	WHERE site_id = ?
+	`
+
+	rows, err := db.Query(query, siteID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query plugins for site %d: %w", siteID, err)
+	}
+	defer rows.Close()
+
+	var plugins []models.WPPlugin
+	for rows.Next() {
+		var p models.WPPlugin
+		err := rows.Scan(
+			&p.SiteID,
+			&p.Name,
+			&p.Status,
+			&p.Version,
+			&p.Update,
+			&p.AutoUpdate,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan site plugin: %w", err)
+		}
+		plugins = append(plugins, p)
+	}
+
+	return plugins, nil
+}
+
+// DeleteSitePlugins removes all plugin records for a specific site.
+// This is useful when performing a full refresh of a site's plugin list.
+func DeleteSitePlugins(siteID int) error {
+	db := GetDB()
+	if db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	query := `DELETE FROM site_plugins WHERE site_id = ?`
+	_, err := db.Exec(query, siteID)
+	if err != nil {
+		return fmt.Errorf("failed to delete plugins for site %d: %w", siteID, err)
+	}
+
+	return nil
+}
+
+// GetAllSitePlugins retrieves every plugin instance across all sites.
+func GetAllSitePlugins() ([]models.WPPlugin, error) {
+	db := GetDB()
+	if db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := `SELECT site_id, slug, status, version, update_available, auto_update FROM site_plugins`
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query all site plugins: %w", err)
+	}
+	defer rows.Close()
+
+	var plugins []models.WPPlugin
+	for rows.Next() {
+		var p models.WPPlugin
+		err := rows.Scan(
+			&p.SiteID,
+			&p.Name,
+			&p.Status,
+			&p.Version,
+			&p.Update,
+			&p.AutoUpdate,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan site plugin: %w", err)
+		}
+		plugins = append(plugins, p)
+	}
+
+	return plugins, nil
+}
+
+// GetSitesWithPlugin returns a list of site IDs where a specific plugin is installed.
+func GetSitesWithPlugin(slug string) ([]int, error) {
+	db := GetDB()
+	if db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := `SELECT site_id FROM site_plugins WHERE slug = ? AND status NOT IN ('must-use', 'dropin')`
+	rows, err := db.Query(query, slug)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query sites for plugin %s: %w", slug, err)
+	}
+	defer rows.Close()
+
+	var siteIDs []int
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan site id: %w", err)
+		}
+		siteIDs = append(siteIDs, id)
+	}
+
+	return siteIDs, nil
+}

--- a/internal/models/plugin.go
+++ b/internal/models/plugin.go
@@ -1,5 +1,7 @@
 package models
 
+import "github.com/JCO-Digital/jman/internal/utils"
+
 // WPPlugin represents a WordPress plugin installed on a specific site.
 type WPPlugin struct {
 	SiteID     int    `json:"site_id"`
@@ -34,4 +36,14 @@ type PluginInfo struct {
 	Tested        string `json:"tested"`
 	LastUpdated   string `json:"last_updated"`
 	Homepage      string `json:"homepage"`
+}
+
+// SanitizePluginInfo normalizes fields in PluginInfo.
+func SanitizePluginInfo(info *PluginInfo) {
+	if info == nil {
+		return
+	}
+
+	info.Name = utils.CleanHTML(info.Name)
+	info.Author = utils.CleanHTML(info.Author)
 }

--- a/internal/wpcli/core.go
+++ b/internal/wpcli/core.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/JCO-Digital/jman/internal/models"
 	"github.com/JCO-Digital/jman/internal/verb"
 )
 
@@ -17,8 +18,8 @@ type CoreUpdate struct {
 }
 
 // Check WordPress core for updates and return the available updates if any.
-func CheckCore(ssh, path string) ([]CoreUpdate, error) {
-	res, err := RunWP(CliOptions{SSH: ssh, Path: path}, "core", "check-update", "--format=json")
+func CheckCore(site models.CliSite) ([]CoreUpdate, error) {
+	res, err := RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path}, "core", "check-update", "--format=json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to check core updates: %w (stderr: %s)", err, res.Error)
 	}
@@ -45,14 +46,14 @@ type CoreUpdateResult struct {
 }
 
 // UpdateCore updates WordPress core to the latest minor version. It returns the new version and language if an update was performed.
-func UpdateCore(ssh, path string) (CoreUpdateResult, error) {
+func UpdateCore(site models.CliSite) (CoreUpdateResult, error) {
 	result := CoreUpdateResult{
 		Success:  false,
 		Version:  "unknown",
 		Language: "",
 	}
 
-	res, err := RunWP(CliOptions{SSH: ssh, Path: path}, "core", "update", "--minor")
+	res, err := RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path}, "core", "update", "--minor")
 	if err != nil {
 		return result, fmt.Errorf("failed to update core: %w (stderr: %s)", err, res.Error)
 	}
@@ -75,7 +76,7 @@ func UpdateCore(ssh, path string) (CoreUpdateResult, error) {
 	}
 	result.Success = true
 
-	res, err = RunWP(CliOptions{SSH: ssh, Path: path}, "core", "update-db")
+	res, err = RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path}, "core", "update-db")
 	if err != nil {
 		return result, fmt.Errorf("failed to update core database: %w (stderr: %s)", err, res.Error)
 	}
@@ -85,8 +86,8 @@ func UpdateCore(ssh, path string) (CoreUpdateResult, error) {
 }
 
 // CoreVersion returns the current WordPress core version on the target site.
-func CoreVersion(ssh, path string) (string, error) {
-	res, err := RunWP(CliOptions{SSH: ssh, Path: path}, "core", "version")
+func CoreVersion(site models.CliSite) (string, error) {
+	res, err := RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path}, "core", "version")
 	if err != nil {
 		return "", fmt.Errorf("failed to show core version: %w (stderr: %s)", err, res.Error)
 	}

--- a/internal/wpcli/plugins.go
+++ b/internal/wpcli/plugins.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/JCO-Digital/jman/internal/models"
 	"github.com/JCO-Digital/jman/internal/verb"
@@ -11,7 +12,7 @@ import (
 
 // GetPlugins returns a list of installed plugins on the target site.
 func GetPlugins(site models.CliSite, skipPlugins bool) ([]models.WPPlugin, error) {
-	res, err := RunWP(CliOptions{SSH: site.SSH, Path: site.Path, IncludePlugins: !skipPlugins}, "plugin", "list", "--format=json")
+	res, err := RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path, IncludePlugins: !skipPlugins}, "plugin", "list", "--format=json")
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +54,7 @@ func GetPlugins(site models.CliSite, skipPlugins bool) ([]models.WPPlugin, error
 }
 
 // AddPlugin installs and optionally activates a plugin.
-func AddPlugin(ssh, path, plugin string, activate bool) (bool, error) {
+func AddPlugin(site models.CliSite, plugin string, activate bool) (bool, error) {
 	args := []string{"plugin", "install", plugin}
 
 	// If the plugin is a ZIP file (local or URL), add --force to allow updating.
@@ -65,7 +66,7 @@ func AddPlugin(ssh, path, plugin string, activate bool) (bool, error) {
 	if activate {
 		args = append(args, "--activate")
 	}
-	res, err := RunWP(CliOptions{SSH: ssh, Path: path, IncludePlugins: true}, args...)
+	res, err := RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path, IncludePlugins: true}, args...)
 	if err != nil {
 		if strings.Contains(res.Error, "Plugin not found.") {
 			return false, fmt.Errorf("plugin not found")
@@ -85,7 +86,7 @@ type UpdateResult struct {
 }
 
 // UpdatePlugin updates one or more plugins.
-func UpdatePlugin(ssh, path string, plugins []string) ([]UpdateResult, error) {
+func UpdatePlugin(site models.CliSite, plugins []string) ([]UpdateResult, error) {
 	if len(plugins) == 0 {
 		return nil, nil
 	}
@@ -94,7 +95,7 @@ func UpdatePlugin(ssh, path string, plugins []string) ([]UpdateResult, error) {
 	args = append(args, plugins...)
 	args = append(args, "--format=json")
 
-	res, err := RunWP(CliOptions{SSH: ssh, Path: path, IncludePlugins: true}, args...)
+	res, err := RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path, IncludePlugins: true}, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update plugin: %w (stderr: %s)", err, res.Error)
 	}
@@ -113,16 +114,20 @@ func UpdatePlugin(ssh, path string, plugins []string) ([]UpdateResult, error) {
 }
 
 // RemovePlugin uninstalls and deactivates a plugin.
-func RemovePlugin(ssh, path, plugin string) (bool, error) {
-	res, err := RunWP(CliOptions{SSH: ssh, Path: path, IncludePlugins: true}, "plugin", "uninstall", plugin, "--deactivate")
+func RemovePlugin(site models.CliSite, plugin string) (bool, error) {
+	res, err := RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path, IncludePlugins: true}, "plugin", "uninstall", plugin, "--deactivate")
 	if err != nil {
 		return false, fmt.Errorf("failed to remove plugin: %w (stderr: %s)", err, res.Error)
 	}
 	return strings.Contains(res.Output, "Success: Uninstalled"), nil
 }
 
-func GetPluginInfo(ssh, path, plugin string) (*models.PluginInfo, error) {
-	res, err := RunWP(CliOptions{SSH: ssh, Path: path, IncludePlugins: true}, "plugin", "get", plugin, "--format=json")
+func GetPluginInfo(site models.CliSite, plugin string, timeout ...time.Duration) (*models.PluginInfo, error) {
+	t := time.Duration(0)
+	if len(timeout) > 0 {
+		t = timeout[0]
+	}
+	res, err := RunWP(CliOptions{SiteID: site.ID, SSH: site.SSH, Path: site.Path, IncludePlugins: true, Timeout: t}, "plugin", "get", plugin, "--format=json")
 	if err != nil {
 		if strings.Contains(res.Error, "plugin could not be found.") {
 			return nil, fmt.Errorf("plugin %s not found", plugin)

--- a/internal/wpcli/tracker.go
+++ b/internal/wpcli/tracker.go
@@ -1,0 +1,37 @@
+package wpcli
+
+import (
+	"sync"
+)
+
+var (
+	siteTrackerMu sync.RWMutex
+	// siteFailures maps site IDs to the number of consecutive connection failures.
+	siteFailures = make(map[int]int)
+)
+
+// RecordFailure increments the failure count for a specific site.
+func RecordFailure(siteID int) {
+	siteTrackerMu.Lock()
+	defer siteTrackerMu.Unlock()
+	siteFailures[siteID]++
+}
+
+// RecordSuccess resets the failure count for a specific site.
+func RecordSuccess(siteID int) {
+	siteTrackerMu.Lock()
+	defer siteTrackerMu.Unlock()
+	delete(siteFailures, siteID)
+}
+
+// GetFailureCount returns the number of recorded failures for a site.
+func GetFailureCount(siteID int) int {
+	siteTrackerMu.RLock()
+	defer siteTrackerMu.RUnlock()
+	return siteFailures[siteID]
+}
+
+// IsSiteHealthy returns true if a site has no recorded failures.
+func IsSiteHealthy(siteID int) bool {
+	return GetFailureCount(siteID) == 0
+}

--- a/internal/wpcli/wpcli.go
+++ b/internal/wpcli/wpcli.go
@@ -2,18 +2,22 @@ package wpcli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/JCO-Digital/jman/internal/verb"
 )
 
 type CliOptions struct {
+	SiteID         int
 	SSH            string
 	Path           string
 	IncludePlugins bool
 	IncludeThemes  bool
+	Timeout        time.Duration
 }
 
 type RunResult struct {
@@ -45,7 +49,14 @@ func RunWP(opts CliOptions, args ...string) (RunResult, error) {
 
 	fullArgs = append(fullArgs, args...)
 
-	cmd := exec.Command("wp", fullArgs...)
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 1 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "wp", fullArgs...)
 
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -58,6 +69,14 @@ func RunWP(opts CliOptions, args ...string) (RunResult, error) {
 	}
 
 	verb.Printf(verb.Debug, "Command output:\n%s\n\nError output:\n%s", res.Output, res.Error)
+
+	if opts.SiteID != 0 {
+		if err != nil {
+			RecordFailure(opts.SiteID)
+		} else {
+			RecordSuccess(opts.SiteID)
+		}
+	}
 
 	// If cmd.Run() returned an error (non-zero exit code), look for the first error line.
 	if err != nil {
@@ -129,7 +148,11 @@ func RunSSH(ssh string, args ...string) (RunResult, error) {
 	}
 
 	cmdArgs := append([]string{ssh}, args...)
-	cmd := exec.Command("ssh", cmdArgs...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ssh", cmdArgs...)
 
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf


### PR DESCRIPTION
- Replace filesystem-based plugin caching with SQLite database storage
- Add `site_plugins` schema and CRUD operations for per-site plugin management
- Update `GetCachedPlugins` to query the database directly
- Refactor `wpcli` to use site objects and implement request timeouts and error tracking