### PR TITLE
feat(api): implement user settings management endpoints

### DIFF
--- a/docs/API_SPECS.md
+++ b/docs/API_SPECS.md
@@ -258,6 +258,74 @@ These endpoints require at least **`basic`** level.
 
 ---
 
+## Settings Management
+
+These endpoints allow users to store arbitrary key/value pairs for frontend configuration or personal preferences. Settings are private to each user.
+
+### List All Settings
+
+`GET /settings` (Protected: `basic`)
+
+Returns all settings for the authenticated user.
+
+**Response (200 OK)**
+
+```json
+[
+	{
+		"user_id": "username",
+		"key": "theme",
+		"value": { "dark": true },
+		"created_at": "datetime",
+		"updated_at": "datetime"
+	}
+]
+```
+
+### Get Setting
+
+`GET /settings/{key}` (Protected: `basic`)
+
+Returns a specific setting by key.
+
+**Response (200 OK)**
+
+```json
+{
+	"user_id": "username",
+	"key": "theme",
+	"value": { "dark": true },
+	"created_at": "datetime",
+	"updated_at": "datetime"
+}
+```
+
+### Create or Replace Setting
+
+`POST /settings/{key}` (Protected: `basic`)
+
+Creates a new setting or completely replaces an existing one.
+
+**Request Body**
+Any valid JSON object.
+
+### Merge Update Setting
+
+`PATCH /settings/{key}` (Protected: `basic`)
+
+Merges the provided JSON object with the existing setting. If both the current value and the new value are JSON objects (maps), they are merged. Otherwise, the value is replaced.
+
+**Request Body**
+Any valid JSON object.
+
+### Delete Setting
+
+`DELETE /settings/{key}` (Protected: `basic`)
+
+Removes the setting with the specified key.
+
+---
+
 ## Error Handling
 
 The API returns a standard error object for all non-2xx/3xx responses:

--- a/docs/API_SPECS.md
+++ b/docs/API_SPECS.md
@@ -307,16 +307,16 @@ Returns a specific setting by key.
 Creates a new setting or completely replaces an existing one.
 
 **Request Body**
-Any valid JSON object.
+Any valid JSON value.
 
 ### Merge Update Setting
 
 `PATCH /settings/{key}` (Protected: `basic`)
 
-Merges the provided JSON object with the existing setting. If both the current value and the new value are JSON objects (maps), they are merged. Otherwise, the value is replaced.
+Merges the provided JSON object with the existing setting. If both the current value and the new value are JSON objects (maps), they are merged. Otherwise, the value is replaced. Returns `404 Not Found` if the setting does not exist.
 
 **Request Body**
-Any valid JSON object.
+Any valid JSON value.
 
 ### Delete Setting
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -92,6 +92,13 @@ func RegisterHandlers(mux *http.ServeMux, version string, usersCfg config.UsersC
 	mux.Handle("POST /api/notes", edit(CreateNoteHandler))
 	mux.Handle("PATCH /api/notes/{id}", edit(UpdateNoteHandler))
 	mux.Handle("DELETE /api/notes/{id}", edit(DeleteNoteHandler))
+
+	// --- Settings routes ---
+	mux.Handle("GET /api/settings", basic(ListSettingsHandler))
+	mux.Handle("GET /api/settings/{key}", basic(GetSettingHandler))
+	mux.Handle("POST /api/settings/{key}", basic(SaveSettingHandler))
+	mux.Handle("PATCH /api/settings/{key}", basic(PatchSettingHandler))
+	mux.Handle("DELETE /api/settings/{key}", basic(DeleteSettingHandler))
 }
 
 // HealthHandler returns a simple health check response.

--- a/internal/api/settings_handlers.go
+++ b/internal/api/settings_handlers.go
@@ -119,22 +119,22 @@ func PatchSettingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if existing == nil {
+		WriteError(w, http.StatusNotFound, "Setting not found")
+		return
+	}
+
 	var finalValue any
-	if existing != nil {
-		// If both are maps, merge them
-		existingMap, ok1 := existing.Value.(map[string]any)
-		patchMap, ok2 := patchValue.(map[string]any)
-		if ok1 && ok2 {
-			for k, v := range patchMap {
-				existingMap[k] = v
-			}
-			finalValue = existingMap
-		} else {
-			// If either is not a map, PATCH behaves like POST (replace)
-			finalValue = patchValue
+	// If both are maps, merge them
+	existingMap, ok1 := existing.Value.(map[string]any)
+	patchMap, ok2 := patchValue.(map[string]any)
+	if ok1 && ok2 {
+		for k, v := range patchMap {
+			existingMap[k] = v
 		}
+		finalValue = existingMap
 	} else {
-		// No existing setting, just use the new value
+		// If either is not a map, PATCH behaves like POST (replace)
 		finalValue = patchValue
 	}
 

--- a/internal/api/settings_handlers.go
+++ b/internal/api/settings_handlers.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/JCO-Digital/jman/internal/db"
+	"github.com/JCO-Digital/jman/internal/models"
+	"github.com/JCO-Digital/jman/internal/verb"
+)
+
+// ListSettingsHandler returns all settings for the authenticated user.
+func ListSettingsHandler(w http.ResponseWriter, r *http.Request) {
+	claims := GetAuthClaims(r.Context())
+	if claims == nil {
+		WriteError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	settings, err := db.GetAllSettings(claims.Username)
+	if err != nil {
+		verb.LogPrintf(verb.Normal, "Failed to get settings for user %s: %v", claims.Username, err)
+		WriteError(w, http.StatusInternalServerError, "Internal server error")
+		return
+	}
+
+	// Ensure we return an empty array instead of null if no settings exist
+	if settings == nil {
+		settings = []models.Setting{}
+	}
+
+	WriteJSON(w, http.StatusOK, settings)
+}
+
+// GetSettingHandler returns a specific setting for the authenticated user by key.
+func GetSettingHandler(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+	if key == "" {
+		WriteError(w, http.StatusBadRequest, "Key is required")
+		return
+	}
+
+	claims := GetAuthClaims(r.Context())
+	if claims == nil {
+		WriteError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	setting, err := db.GetSetting(claims.Username, key)
+	if err != nil {
+		verb.LogPrintf(verb.Normal, "Failed to get setting %s for user %s: %v", key, claims.Username, err)
+		WriteError(w, http.StatusInternalServerError, "Internal server error")
+		return
+	}
+
+	if setting == nil {
+		WriteError(w, http.StatusNotFound, "Setting not found")
+		return
+	}
+
+	WriteJSON(w, http.StatusOK, setting)
+}
+
+// SaveSettingHandler creates or replaces a setting for the authenticated user.
+func SaveSettingHandler(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+	if key == "" {
+		WriteError(w, http.StatusBadRequest, "Key is required")
+		return
+	}
+
+	claims := GetAuthClaims(r.Context())
+	if claims == nil {
+		WriteError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	var value any
+	if err := json.NewDecoder(r.Body).Decode(&value); err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid JSON payload")
+		return
+	}
+
+	setting, err := db.SaveSetting(claims.Username, key, value)
+	if err != nil {
+		verb.LogPrintf(verb.Normal, "Failed to save setting %s for user %s: %v", key, claims.Username, err)
+		WriteError(w, http.StatusInternalServerError, "Internal server error")
+		return
+	}
+
+	WriteJSON(w, http.StatusOK, setting)
+}
+
+// PatchSettingHandler creates or updates a setting by merging the new value with the existing one.
+// This merge only applies if both the existing value and the new value are JSON objects (maps).
+func PatchSettingHandler(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+	if key == "" {
+		WriteError(w, http.StatusBadRequest, "Key is required")
+		return
+	}
+
+	claims := GetAuthClaims(r.Context())
+	if claims == nil {
+		WriteError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	var patchValue any
+	if err := json.NewDecoder(r.Body).Decode(&patchValue); err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid JSON payload")
+		return
+	}
+
+	existing, err := db.GetSetting(claims.Username, key)
+	if err != nil {
+		verb.LogPrintf(verb.Normal, "Failed to get existing setting %s for user %s: %v", key, claims.Username, err)
+		WriteError(w, http.StatusInternalServerError, "Internal server error")
+		return
+	}
+
+	var finalValue any
+	if existing != nil {
+		// If both are maps, merge them
+		existingMap, ok1 := existing.Value.(map[string]any)
+		patchMap, ok2 := patchValue.(map[string]any)
+		if ok1 && ok2 {
+			for k, v := range patchMap {
+				existingMap[k] = v
+			}
+			finalValue = existingMap
+		} else {
+			// If either is not a map, PATCH behaves like POST (replace)
+			finalValue = patchValue
+		}
+	} else {
+		// No existing setting, just use the new value
+		finalValue = patchValue
+	}
+
+	setting, err := db.SaveSetting(claims.Username, key, finalValue)
+	if err != nil {
+		verb.LogPrintf(verb.Normal, "Failed to patch setting %s for user %s: %v", key, claims.Username, err)
+		WriteError(w, http.StatusInternalServerError, "Internal server error")
+		return
+	}
+
+	WriteJSON(w, http.StatusOK, setting)
+}
+
+// DeleteSettingHandler removes a setting for the authenticated user.
+func DeleteSettingHandler(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+	if key == "" {
+		WriteError(w, http.StatusBadRequest, "Key is required")
+		return
+	}
+
+	claims := GetAuthClaims(r.Context())
+	if claims == nil {
+		WriteError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	if err := db.DeleteSetting(claims.Username, key); err != nil {
+		verb.LogPrintf(verb.Normal, "Failed to delete setting %s for user %s: %v", key, claims.Username, err)
+		WriteError(w, http.StatusInternalServerError, "Internal server error")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/settings_handlers_test.go
+++ b/internal/api/settings_handlers_test.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/JCO-Digital/jman/internal/config"
+	"github.com/JCO-Digital/jman/internal/db"
+	"github.com/JCO-Digital/jman/internal/models"
+)
+
+func setupSettingsTest(t *testing.T) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "jman-settings-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	// Store old data dir to restore later
+	oldDataDir := config.RunData.DataDir
+	config.RunData.DataDir = tempDir
+
+	if err := db.Init(); err != nil {
+		t.Fatalf("Failed to init DB: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Close()
+		os.RemoveAll(tempDir)
+		config.RunData.DataDir = oldDataDir
+	})
+}
+
+func TestListSettingsHandler(t *testing.T) {
+	setupSettingsTest(t)
+	username := "listuser"
+	claims := &AuthClaims{Username: username, Level: config.LevelBasic}
+	ctx := contextWithClaims(context.Background(), claims)
+
+	// Initially empty list
+	req := httptest.NewRequest("GET", "/api/settings", nil)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	ListSettingsHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected 200 OK, got %d", w.Code)
+	}
+	var settings []models.Setting
+	if err := json.Unmarshal(w.Body.Bytes(), &settings); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if len(settings) != 0 {
+		t.Errorf("Expected 0 settings, got %d", len(settings))
+	}
+
+	// Add a setting and check again
+	_, err := db.SaveSetting(username, "theme", map[string]string{"color": "blue"})
+	if err != nil {
+		t.Fatalf("Failed to save setting: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	ListSettingsHandler(w, req)
+	if err := json.Unmarshal(w.Body.Bytes(), &settings); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if len(settings) != 1 {
+		t.Errorf("Expected 1 setting, got %d", len(settings))
+	}
+}
+
+func TestGetSettingHandler(t *testing.T) {
+	setupSettingsTest(t)
+	username := "getuser"
+	key := "my-preference"
+	claims := &AuthClaims{Username: username, Level: config.LevelBasic}
+	ctx := contextWithClaims(context.Background(), claims)
+
+	// Test 404
+	req := httptest.NewRequest("GET", "/api/settings/"+key, nil)
+	req.SetPathValue("key", key)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	GetSettingHandler(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected 404 Not Found, got %d", w.Code)
+	}
+
+	// Test Success
+	_, _ = db.SaveSetting(username, key, "some-value")
+	w = httptest.NewRecorder()
+	GetSettingHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected 200 OK, got %d", w.Code)
+	}
+	var s models.Setting
+	if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+	if s.Key != key {
+		t.Errorf("Expected key %s, got %s", key, s.Key)
+	}
+}
+
+func TestSaveSettingHandler(t *testing.T) {
+	setupSettingsTest(t)
+	username := "saveuser"
+	key := "ui-config"
+	claims := &AuthClaims{Username: username, Level: config.LevelBasic}
+	ctx := contextWithClaims(context.Background(), claims)
+
+	val := map[string]any{"sidebar": "collapsed", "items": 10}
+	body, _ := json.Marshal(val)
+	req := httptest.NewRequest("POST", "/api/settings/"+key, bytes.NewBuffer(body))
+	req.SetPathValue("key", key)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	SaveSettingHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected 200 OK, got %d", w.Code)
+	}
+
+	var saved models.Setting
+	json.Unmarshal(w.Body.Bytes(), &saved)
+	if saved.Key != key {
+		t.Errorf("Expected key %s, got %s", key, saved.Key)
+	}
+
+	// Verify persistence
+	dbSetting, _ := db.GetSetting(username, key)
+	if dbSetting == nil {
+		t.Fatal("Setting was not found in database")
+	}
+}
+
+func TestPatchSettingHandler(t *testing.T) {
+	setupSettingsTest(t)
+	username := "patchuser"
+	key := "merge-test"
+	claims := &AuthClaims{Username: username, Level: config.LevelBasic}
+	ctx := contextWithClaims(context.Background(), claims)
+
+	// 1. Patch non-existent setting should return 404
+	patchVal := map[string]any{"new": "data"}
+	body, _ := json.Marshal(patchVal)
+	req := httptest.NewRequest("PATCH", "/api/settings/"+key, bytes.NewBuffer(body))
+	req.SetPathValue("key", key)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	PatchSettingHandler(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected 404 for non-existent patch, got %d", w.Code)
+	}
+
+	// 2. Create and then patch (merge objects)
+	initial := map[string]any{"a": 1, "b": 2}
+	db.SaveSetting(username, key, initial)
+
+	patch := map[string]any{"b": 20, "c": 30}
+	pBody, _ := json.Marshal(patch)
+	req = httptest.NewRequest("PATCH", "/api/settings/"+key, bytes.NewBuffer(pBody))
+	req.SetPathValue("key", key)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	PatchSettingHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected 200 OK, got %d", w.Code)
+	}
+
+	var patched models.Setting
+	json.Unmarshal(w.Body.Bytes(), &patched)
+	m, ok := patched.Value.(map[string]any)
+	if !ok {
+		t.Fatalf("Value is not a map: %T", patched.Value)
+	}
+	if m["a"].(float64) != 1 || m["b"].(float64) != 20 || m["c"].(float64) != 30 {
+		t.Errorf("Merge result incorrect: %+v", m)
+	}
+}
+
+func TestDeleteSettingHandler(t *testing.T) {
+	setupSettingsTest(t)
+	username := "deluser"
+	key := "ephemeral"
+	db.SaveSetting(username, key, "temporary")
+
+	req := httptest.NewRequest("DELETE", "/api/settings/"+key, nil)
+	req.SetPathValue("key", key)
+	claims := &AuthClaims{Username: username, Level: config.LevelBasic}
+	req = req.WithContext(contextWithClaims(context.Background(), claims))
+	w := httptest.NewRecorder()
+
+	DeleteSettingHandler(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 No Content, got %d", w.Code)
+	}
+
+	// Verify it's gone
+	s, _ := db.GetSetting(username, key)
+	if s != nil {
+		t.Error("Setting still exists in database after DELETE")
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -306,6 +306,17 @@ func initSchema() error {
 				"updated_by":  "TEXT",
 			},
 		},
+		{
+			Name: "settings",
+			Columns: map[string]string{
+				"user_id":    "TEXT NOT NULL",
+				"key":        "TEXT NOT NULL",
+				"value":      "TEXT",
+				"created_at": "DATETIME DEFAULT CURRENT_TIMESTAMP",
+				"updated_at": "DATETIME DEFAULT CURRENT_TIMESTAMP",
+			},
+			PrimaryKey: []string{"user_id", "key"},
+		},
 	}
 
 	for _, table := range tables {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -311,7 +311,7 @@ func initSchema() error {
 			Columns: map[string]string{
 				"user_id":    "TEXT NOT NULL",
 				"key":        "TEXT NOT NULL",
-				"value":      "TEXT",
+				"value":      "TEXT NOT NULL",
 				"created_at": "DATETIME DEFAULT CURRENT_TIMESTAMP",
 				"updated_at": "DATETIME DEFAULT CURRENT_TIMESTAMP",
 			},

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -14,7 +14,6 @@ import (
 
 var (
 	dbInstance *sql.DB
-	once       sync.Once
 	dbMutex    sync.Mutex
 )
 
@@ -28,54 +27,58 @@ type TableDefinition struct {
 // Init initializes the SQLite database.
 // It creates the database file in the data directory if it doesn't exist.
 func Init() error {
-	var err error
-	once.Do(func() {
-		dbPath := filepath.Join(config.RunData.DataDir, "jman.db")
+	dbMutex.Lock()
+	defer dbMutex.Unlock()
 
-		// Open the database connection.
-		db, openErr := sql.Open("sqlite", dbPath)
-		if openErr != nil {
-			err = fmt.Errorf("failed to open database: %w", openErr)
-			return
+	if dbInstance != nil {
+		return nil
+	}
+
+	dbPath := filepath.Join(config.RunData.DataDir, "jman.db")
+
+	// Open the database connection.
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+
+	// Limit to a single connection to avoid "database is locked" errors.
+	// SQLite works best with a single connection when performing concurrent writes.
+	db.SetMaxOpenConns(1)
+
+	// Set pragmas for better concurrency and reliability.
+	// WAL mode allows multiple readers and one writer simultaneously.
+	// Busy timeout ensures it retries before failing with SQLITE_BUSY.
+	pragmas := []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA synchronous=NORMAL",
+		"PRAGMA busy_timeout=5000",
+		"PRAGMA foreign_keys=ON",
+	}
+
+	for _, p := range pragmas {
+		if _, pragmaErr := db.Exec(p); pragmaErr != nil {
+			db.Close()
+			return fmt.Errorf("failed to set pragma %q: %w", p, pragmaErr)
 		}
+	}
 
-		// Limit to a single connection to avoid "database is locked" errors.
-		// SQLite works best with a single connection when performing concurrent writes.
-		db.SetMaxOpenConns(1)
+	// Check connection
+	if pingErr := db.Ping(); pingErr != nil {
+		db.Close()
+		return fmt.Errorf("failed to ping database: %w", pingErr)
+	}
 
-		// Set pragmas for better concurrency and reliability.
-		// WAL mode allows multiple readers and one writer simultaneously.
-		// Busy timeout ensures it retries before failing with SQLITE_BUSY.
-		pragmas := []string{
-			"PRAGMA journal_mode=WAL",
-			"PRAGMA synchronous=NORMAL",
-			"PRAGMA busy_timeout=5000",
-			"PRAGMA foreign_keys=ON",
-		}
+	dbInstance = db
 
-		for _, p := range pragmas {
-			if _, pragmaErr := db.Exec(p); pragmaErr != nil {
-				err = fmt.Errorf("failed to set pragma %q: %w", p, pragmaErr)
-				return
-			}
-		}
+	// Initialize schemas with migration support
+	if schemaErr := initSchema(); schemaErr != nil {
+		db.Close()
+		dbInstance = nil
+		return fmt.Errorf("failed to initialize schema: %w", schemaErr)
+	}
 
-		// Check connection
-		if pingErr := db.Ping(); pingErr != nil {
-			err = fmt.Errorf("failed to ping database: %w", pingErr)
-			return
-		}
-
-		dbInstance = db
-
-		// Initialize schemas with migration support
-		if schemaErr := initSchema(); schemaErr != nil {
-			err = fmt.Errorf("failed to initialize schema: %w", schemaErr)
-			return
-		}
-	})
-
-	return err
+	return nil
 }
 
 // GetDB returns the global database instance.

--- a/internal/db/settings_repo.go
+++ b/internal/db/settings_repo.go
@@ -18,7 +18,7 @@ func GetSetting(userID, key string) (*models.Setting, error) {
 
 	query := `SELECT user_id, key, value, created_at, updated_at FROM settings WHERE user_id = ? AND key = ?`
 	var s models.Setting
-	var valueJSON string
+	var valueJSON sql.NullString
 
 	err := db.QueryRow(query, userID, key).Scan(&s.UserID, &s.Key, &valueJSON, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
@@ -28,8 +28,10 @@ func GetSetting(userID, key string) (*models.Setting, error) {
 		return nil, fmt.Errorf("failed to get setting: %w", err)
 	}
 
-	if err := json.Unmarshal([]byte(valueJSON), &s.Value); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal setting value: %w", err)
+	if valueJSON.Valid {
+		if err := json.Unmarshal([]byte(valueJSON.String), &s.Value); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal setting value: %w", err)
+		}
 	}
 
 	return &s, nil
@@ -52,12 +54,14 @@ func GetAllSettings(userID string) ([]models.Setting, error) {
 	var settings []models.Setting
 	for rows.Next() {
 		var s models.Setting
-		var valueJSON string
+		var valueJSON sql.NullString
 		if err := rows.Scan(&s.UserID, &s.Key, &valueJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, err
 		}
-		if err := json.Unmarshal([]byte(valueJSON), &s.Value); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal setting value for key %s: %w", s.Key, err)
+		if valueJSON.Valid {
+			if err := json.Unmarshal([]byte(valueJSON.String), &s.Value); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal setting value for key %s: %w", s.Key, err)
+			}
 		}
 		settings = append(settings, s)
 	}

--- a/internal/db/settings_repo.go
+++ b/internal/db/settings_repo.go
@@ -1,0 +1,115 @@
+package db
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/JCO-Digital/jman/internal/models"
+)
+
+// GetSetting retrieves a specific setting for a user by key.
+func GetSetting(userID, key string) (*models.Setting, error) {
+	db := GetDB()
+	if db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := `SELECT user_id, key, value, created_at, updated_at FROM settings WHERE user_id = ? AND key = ?`
+	var s models.Setting
+	var valueJSON string
+
+	err := db.QueryRow(query, userID, key).Scan(&s.UserID, &s.Key, &valueJSON, &s.CreatedAt, &s.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get setting: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(valueJSON), &s.Value); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal setting value: %w", err)
+	}
+
+	return &s, nil
+}
+
+// GetAllSettings retrieves all settings for a specific user.
+func GetAllSettings(userID string) ([]models.Setting, error) {
+	db := GetDB()
+	if db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := `SELECT user_id, key, value, created_at, updated_at FROM settings WHERE user_id = ? ORDER BY key ASC`
+	rows, err := db.Query(query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query settings: %w", err)
+	}
+	defer rows.Close()
+
+	var settings []models.Setting
+	for rows.Next() {
+		var s models.Setting
+		var valueJSON string
+		if err := rows.Scan(&s.UserID, &s.Key, &valueJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(valueJSON), &s.Value); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal setting value for key %s: %w", s.Key, err)
+		}
+		settings = append(settings, s)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return settings, nil
+}
+
+// SaveSetting creates or updates a setting for a user.
+func SaveSetting(userID, key string, value any) (*models.Setting, error) {
+	db := GetDB()
+	if db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	valueJSON, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal setting value: %w", err)
+	}
+
+	now := time.Now()
+	query := `
+		INSERT INTO settings (user_id, key, value, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(user_id, key) DO UPDATE SET
+			value = excluded.value,
+			updated_at = excluded.updated_at
+	`
+
+	_, err = db.Exec(query, userID, key, string(valueJSON), now, now)
+	if err != nil {
+		return nil, fmt.Errorf("failed to save setting: %w", err)
+	}
+
+	return GetSetting(userID, key)
+}
+
+// DeleteSetting removes a setting for a user.
+func DeleteSetting(userID, key string) error {
+	db := GetDB()
+	if db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	query := `DELETE FROM settings WHERE user_id = ? AND key = ?`
+	_, err := db.Exec(query, userID, key)
+	if err != nil {
+		return fmt.Errorf("failed to delete setting: %w", err)
+	}
+
+	return nil
+}

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+// Setting represents a user-specific key/value setting.
+// The Value field is expected to be a JSON object (stored as a string in the database).
+type Setting struct {
+	UserID    string    `json:"user_id"`
+	Key       string    `json:"key"`
+	Value     any       `json:"value"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -3,7 +3,7 @@ package models
 import "time"
 
 // Setting represents a user-specific key/value setting.
-// The Value field is expected to be a JSON object (stored as a string in the database).
+// The Value field is assumend to be a JSON object (stored as a string in the database), but can be any value that can be represented as a string.
 type Setting struct {
 	UserID    string    `json:"user_id"`
 	Key       string    `json:"key"`


### PR DESCRIPTION
This pull request introduces a new user settings management feature, allowing users to store, retrieve, update, and delete arbitrary key/value settings (such as frontend configuration or personal preferences). The implementation includes new API endpoints, handlers, database schema changes, repository functions, and a model for user settings.

**API Endpoints and Documentation**

- Added a new "Settings Management" section to the API documentation, specifying endpoints for listing, retrieving, creating/replacing, merging, and deleting user-specific settings. Each endpoint is protected and requires at least `basic` authentication.

**API Handlers**

- Implemented new HTTP handlers in `settings_handlers.go` for all settings-related operations: listing all settings, getting a specific setting, saving (creating/replacing) a setting, patching (merging) a setting, and deleting a setting. These handlers enforce authentication and proper error handling.
- Registered the new settings endpoints in the main API router in `handlers.go`.

**Database Layer**

- Added a new `settings` table to the database schema, with columns for `user_id`, `key`, `value`, `created_at`, and `updated_at`. The primary key is a composite of `user_id` and `key`.
- Implemented repository functions in `settings_repo.go` for CRUD operations on user settings, including JSON marshaling/unmarshaling for the value field.

**Data Model**

- Introduced a new `Setting` struct in `models/settings.go` to represent a user setting, with fields for user ID, key, value (as any type), and timestamps.