### PR TITLE
Feat/update

### DIFF
--- a/docs/API_SPECS.md
+++ b/docs/API_SPECS.md
@@ -326,6 +326,69 @@ Removes the setting with the specified key.
 
 ---
 
+## Plugin Update Operations
+
+These endpoints allow a UI to perform plugin updates one at a time, so progress can be displayed per plugin. Both require the **`execute`** level.
+
+### Get Available Plugin Updates for a Site
+
+`GET /sites/{id}/plugin-updates` (Protected: `execute`)
+
+Calls WP-CLI live to fetch the current list of plugins that have updates available on the specified site.
+
+**Path Parameters**
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `id` | integer | Site ID |
+
+**Response (200 OK)**
+
+```json
+[
+  {
+    "site_id": 123,
+    "name": "akismet",
+    "status": "active",
+    "version": "5.0.0",
+    "update": "5.1.0",
+    "autoUpdate": false
+  }
+]
+```
+
+Returns an empty array if no updates are available.
+
+### Update a Single Plugin on a Site
+
+`POST /sites/{id}/plugin-updates` (Protected: `execute`)
+
+Updates one plugin on the site. The plugin cache is refreshed in the background after the call returns.
+
+**Path Parameters**
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `id` | integer | Site ID |
+
+**Request Body**
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `plugin` | string | Yes | Plugin slug to update |
+
+**Response (200 OK)**
+
+```json
+{
+  "name": "akismet",
+  "old_version": "5.0.0",
+  "new_version": "5.1.0",
+  "status": "Updated"
+}
+```
+
+Returns an empty array if the plugin had no update available. The `status` field reflects the WP-CLI result (e.g. `"Updated"`).
+
+---
+
 ## Error Handling
 
 The API returns a standard error object for all non-2xx/3xx responses:

--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -180,16 +180,22 @@ func SitePluginUpdatesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Persist the freshly-fetched plugin state for this site.
-	if err := db.DeleteSitePlugins(site.ID); err == nil {
-		for _, p := range plugins {
-			_ = db.SaveSitePlugin(p)
-			if p.Status != "must-use" && p.Status != "dropin" {
-				bestVer := p.Version
-				if p.Update != "" {
-					bestVer = p.Update
-				}
-				cache.UpdatePluginInfo(p.Name, "", bestVer)
+	// Delete first to remove plugins that are no longer installed; if that
+	// fails, log and continue — SaveSitePlugin uses ON CONFLICT UPDATE so
+	// existing rows are still refreshed and updated_at is kept current.
+	if err := db.DeleteSitePlugins(site.ID); err != nil {
+		verb.PrintErrorf(verb.Normal, "Warning: failed to clear plugin cache for site %s: %v\n", site.Name, err)
+	}
+	for _, p := range plugins {
+		if err := db.SaveSitePlugin(p); err != nil {
+			verb.PrintErrorf(verb.Normal, "Warning: failed to save plugin %s for site %s: %v\n", p.Name, site.Name, err)
+		}
+		if p.Status != "must-use" && p.Status != "dropin" {
+			bestVer := p.Version
+			if p.Update != "" {
+				bestVer = p.Update
 			}
+			cache.UpdatePluginInfo(p.Name, "", bestVer)
 		}
 	}
 

--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -1,15 +1,18 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
 	"sort"
+	"strconv"
 
 	"github.com/JCO-Digital/jman/internal/cache"
 	"github.com/JCO-Digital/jman/internal/db"
 	"github.com/JCO-Digital/jman/internal/models"
 	"github.com/JCO-Digital/jman/internal/vuln"
+	"github.com/JCO-Digital/jman/internal/wpcli"
 )
 
 // PluginsHandler returns the list of cached WordPress plugins.
@@ -147,4 +150,120 @@ func VulnsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	WriteJSON(w, http.StatusOK, response)
+}
+
+// SitePluginUpdatesHandler returns the list of plugins with available updates for a site.
+// It calls WP-CLI live so the result reflects the current state of the site.
+func SitePluginUpdatesHandler(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid site ID")
+		return
+	}
+
+	site, err := getSiteByID(siteID)
+	if err != nil {
+		WriteError(w, http.StatusNotFound, fmt.Sprintf("Site not found: %v", err))
+		return
+	}
+
+	plugins, err := wpcli.GetPlugins(*site, false)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to get plugins: %v", err))
+		return
+	}
+
+	// Persist the freshly-fetched plugin state for this site.
+	if err := db.DeleteSitePlugins(site.ID); err == nil {
+		for _, p := range plugins {
+			_ = db.SaveSitePlugin(p)
+			if p.Status != "must-use" && p.Status != "dropin" {
+				bestVer := p.Version
+				if p.Update != "" {
+					bestVer = p.Update
+				}
+				cache.UpdatePluginInfo(p.Name, "", bestVer)
+			}
+		}
+	}
+
+	updates := []models.WPPlugin{}
+	for _, p := range plugins {
+		if p.Update != "" {
+			updates = append(updates, p)
+		}
+	}
+
+	WriteJSON(w, http.StatusOK, updates)
+}
+
+// SitePluginUpdateHandler updates a single plugin on a site and refreshes the plugin cache.
+func SitePluginUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid site ID")
+		return
+	}
+
+	var body struct {
+		Plugin string `json:"plugin"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if body.Plugin == "" {
+		WriteError(w, http.StatusBadRequest, "Plugin name is required")
+		return
+	}
+
+	site, err := getSiteByID(siteID)
+	if err != nil {
+		WriteError(w, http.StatusNotFound, fmt.Sprintf("Site not found: %v", err))
+		return
+	}
+
+	results, err := wpcli.UpdatePlugin(*site, []string{body.Plugin})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to update plugin: %v", err))
+		return
+	}
+
+	if len(results) == 0 {
+		WriteJSON(w, http.StatusOK, []wpcli.UpdateResult{})
+		return
+	}
+
+	result := results[0]
+
+	// Persist the new version and clear the pending update flag in the DB.
+	if result.Status == "Updated" {
+		sitePlugins, dbErr := db.GetSitePlugins(site.ID)
+		if dbErr == nil {
+			for _, p := range sitePlugins {
+				if p.Name == body.Plugin {
+					p.Version = result.NewVersion
+					p.Update = ""
+					_ = db.SaveSitePlugin(p)
+					cache.UpdatePluginInfo(p.Name, "", result.NewVersion)
+					break
+				}
+			}
+		}
+	}
+
+	WriteJSON(w, http.StatusOK, result)
+}
+
+func getSiteByID(id int) (*models.CliSite, error) {
+	sites, err := cache.GetFastSiteList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get site list: %w", err)
+	}
+	for _, s := range sites {
+		if s.ID == id {
+			return &s, nil
+		}
+	}
+	return nil, fmt.Errorf("site with ID %d not found", id)
 }

--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/JCO-Digital/jman/internal/cache"
 	"github.com/JCO-Digital/jman/internal/db"
 	"github.com/JCO-Digital/jman/internal/models"
+	"github.com/JCO-Digital/jman/internal/verb"
 	"github.com/JCO-Digital/jman/internal/vuln"
 	"github.com/JCO-Digital/jman/internal/wpcli"
 )
@@ -245,21 +246,13 @@ func SitePluginUpdateHandler(w http.ResponseWriter, r *http.Request) {
 
 	result := results[0]
 
-	// Persist the new version and clear the pending update flag in the DB.
-	if result.Status == "Updated" {
-		sitePlugins, dbErr := db.GetSitePlugins(site.ID)
-		if dbErr == nil {
-			for _, p := range sitePlugins {
-				if p.Name == body.Plugin {
-					p.Version = result.NewVersion
-					p.Update = ""
-					_ = db.SaveSitePlugin(p)
-					cache.UpdatePluginInfo(p.Name, "", result.NewVersion)
-					break
-				}
-			}
+	// Refresh the full plugin list for this site so all versions and
+	// update_available flags reflect the post-update state.
+	go func() {
+		if err := cache.UpdateSitePluginCache(*site); err != nil {
+			verb.PrintErrorf(verb.Normal, "Failed to refresh plugin cache for site %s after update: %v\n", site.Name, err)
 		}
-	}
+	}()
 
 	WriteJSON(w, http.StatusOK, result)
 }

--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 
@@ -14,6 +15,10 @@ import (
 	"github.com/JCO-Digital/jman/internal/vuln"
 	"github.com/JCO-Digital/jman/internal/wpcli"
 )
+
+// pluginSlugRegex matches valid WordPress plugin slugs. The first character must be
+// alphanumeric, which rejects flag-like values such as --all or -p outright.
+var pluginSlugRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9_\-/]*$`)
 
 // PluginsHandler returns the list of cached WordPress plugins.
 func PluginsHandler(w http.ResponseWriter, r *http.Request) {
@@ -214,6 +219,10 @@ func SitePluginUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.Plugin == "" {
 		WriteError(w, http.StatusBadRequest, "Plugin name is required")
+		return
+	}
+	if !pluginSlugRegex.MatchString(body.Plugin) {
+		WriteError(w, http.StatusBadRequest, "Invalid plugin slug: must start with a letter or digit and contain only [a-z0-9_-/]")
 		return
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -26,6 +26,9 @@ func RegisterHandlers(mux *http.ServeMux, version string, usersCfg config.UsersC
 	admin := func(h http.HandlerFunc) http.Handler {
 		return AuthMiddleware(&usersCfg, RequireLevel(config.LevelAdmin)(h))
 	}
+	execute := func(h http.HandlerFunc) http.Handler {
+		return AuthMiddleware(&usersCfg, RequireLevel(config.LevelExecute)(h))
+	}
 	mux.Handle("POST /api/auth/refresh", basic(RefreshHandler(&usersCfg)))
 	mux.Handle("GET /api/plugins", basic(PluginsHandler))
 	mux.Handle("GET /api/plugininfo", basic(PluginInfoHandler))
@@ -86,6 +89,10 @@ func RegisterHandlers(mux *http.ServeMux, version string, usersCfg config.UsersC
 	mux.Handle("GET /api/sites/{id}/organization", basic(GetSiteOrganizationHandler))
 	mux.Handle("POST /api/sites/{id}/link", edit(LinkSiteHandler))
 	mux.Handle("DELETE /api/sites/{id}/link", edit(UnlinkSiteHandler))
+
+	// --- Plugin update routes ---
+	mux.Handle("GET /api/sites/{id}/plugin-updates", execute(SitePluginUpdatesHandler))
+	mux.Handle("POST /api/sites/{id}/plugin-updates", execute(SitePluginUpdateHandler))
 
 	// --- Note routes ---
 	mux.Handle("GET /api/notes", basic(ListNotesHandler))

--- a/internal/cache/plugins.go
+++ b/internal/cache/plugins.go
@@ -27,9 +27,10 @@ func GetCachedPlugins(ttl ...time.Duration) ([]models.WPPlugin, error) {
 		return nil, fmt.Errorf("failed to get existing plugins from database: %w", err)
 	}
 
-	hasPlugins := make(map[int]bool)
-	for _, p := range existingPlugins {
-		hasPlugins[p.SiteID] = true
+	lastUpdates, err := db.GetSitePluginLastUpdates()
+	if err != nil {
+		verb.PrintErrorf(verb.Verbose, "Warning: failed to get plugin last updates from database: %v\n", err)
+		lastUpdates = make(map[int]string)
 	}
 
 	sites, err := GetSiteList()
@@ -43,9 +44,17 @@ func GetCachedPlugins(ttl ...time.Duration) ([]models.WPPlugin, error) {
 	var mu sync.Mutex
 
 	for _, site := range sites {
-		// Skip sites that already have cached plugins unless forcing a refresh.
-		if hasPlugins[site.ID] && !force {
-			continue
+		// Skip sites that already have cached plugins unless forcing a refresh or expired.
+		if !force {
+			if lastUpdate, ok := lastUpdates[site.ID]; ok && lastUpdate != "" {
+				if t == -1 {
+					continue
+				}
+				lu, err := time.ParseInLocation("2006-01-02 15:04:05", lastUpdate, time.UTC)
+				if err == nil && time.Now().UTC().Sub(lu) < t {
+					continue
+				}
+			}
 		}
 
 		site := site

--- a/internal/cache/plugins.go
+++ b/internal/cache/plugins.go
@@ -33,6 +33,14 @@ func GetCachedPlugins(ttl ...time.Duration) ([]models.WPPlugin, error) {
 		lastUpdates = make(map[int]string)
 	}
 
+	// Build a presence set from existing rows so that a missing or failed
+	// lastUpdates lookup doesn't cause every site to be re-fetched when the
+	// caller requested no refresh (t == -1) or when data clearly exists.
+	sitesWithData := make(map[int]bool, len(existingPlugins))
+	for _, p := range existingPlugins {
+		sitesWithData[p.SiteID] = true
+	}
+
 	sites, err := GetSiteList()
 	if err != nil {
 		return existingPlugins, fmt.Errorf("failed to get site list: %w", err)
@@ -54,6 +62,9 @@ func GetCachedPlugins(ttl ...time.Duration) ([]models.WPPlugin, error) {
 				if err == nil && time.Now().UTC().Sub(lu) < t {
 					continue
 				}
+			} else if t == -1 && sitesWithData[site.ID] {
+				// No timestamp available but data exists and caller requested no refresh.
+				continue
 			}
 		}
 

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -65,7 +65,7 @@ var (
 				}
 
 				if fetchPlugins {
-					verb.Print(verb.Verbose, "Fetching plugins.")
+					verb.PrintErrorln(verb.Normal, "Fetching plugins.")
 				}
 
 				plugins, err := cache.GetCachedPlugins(pTTL)

--- a/internal/db/site_plugins.go
+++ b/internal/db/site_plugins.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 
 	"github.com/JCO-Digital/jman/internal/models"
@@ -155,4 +156,31 @@ func GetSitesWithPlugin(slug string) ([]int, error) {
 	}
 
 	return siteIDs, nil
+}
+
+// GetSitePluginLastUpdates returns a map of site IDs to their last plugin update timestamp.
+func GetSitePluginLastUpdates() (map[int]string, error) {
+	db := GetDB()
+	if db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := `SELECT site_id, MAX(updated_at) FROM site_plugins GROUP BY site_id`
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query plugin updates: %w", err)
+	}
+	defer rows.Close()
+
+	updates := make(map[int]string)
+	for rows.Next() {
+		var siteID int
+		var updatedAt sql.NullString
+		if err := rows.Scan(&siteID, &updatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan plugin update: %w", err)
+		}
+		updates[siteID] = updatedAt.String
+	}
+
+	return updates, nil
 }

--- a/internal/db/site_plugins.go
+++ b/internal/db/site_plugins.go
@@ -181,6 +181,9 @@ func GetSitePluginLastUpdates() (map[int]string, error) {
 		}
 		updates[siteID] = updatedAt.String
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating plugin updates: %w", err)
+	}
 
 	return updates, nil
 }


### PR DESCRIPTION
This pull request adds new API endpoints for updating WordPress plugins on a per-site basis, improves plugin cache freshness logic, and introduces supporting backend changes. The main focus is to enable the UI to display and trigger plugin updates for individual sites, with real-time progress and improved cache management.

**API Enhancements:**

* Added two new endpoints: `GET /sites/{id}/plugin-updates` to fetch available plugin updates for a site, and `POST /sites/{id}/plugin-updates` to update a single plugin on a site. Both require the `execute` permission level and are documented in `API_SPECS.md`. [[1]](diffhunk://#diff-bd57855cfb0d9ca8a90fdca7b4fdf1ff02888e36bf4f197d55cacef2d1fbfe12R329-R391) [[2]](diffhunk://#diff-6c6fe69fba99e4fd8a5b14a2751c6ef8363e4054217bbaab768340dedfb72735R93-R96)
* Implemented `SitePluginUpdatesHandler` and `SitePluginUpdateHandler` in `data_handlers.go` to support the new endpoints, including live WP-CLI calls, plugin state persistence, and cache updates.

**Plugin Cache Improvements:**

* Enhanced plugin cache freshness: `GetCachedPlugins` now checks the last plugin update timestamp per site (using `GetSitePluginLastUpdates`) to determine if a refresh is needed, instead of only checking for existence. [[1]](diffhunk://#diff-51621c42b4aea8d12a426077a555c544019e4658ff8f041572f1fb973c91c406L30-R33) [[2]](diffhunk://#diff-51621c42b4aea8d12a426077a555c544019e4658ff8f041572f1fb973c91c406L46-R58) [[3]](diffhunk://#diff-9b3f13a0280a67744d39acaf17f186b64dc3bdfc96ca56bd27cf7f76d164138eR160-R186)
* Added `GetSitePluginLastUpdates` to `db/site_plugins.go` to retrieve the latest plugin update timestamps for all sites.

**Other Minor Updates:**

* Improved logging for plugin fetch operations.
* Added necessary imports for new functionality in backend files. [[1]](diffhunk://#diff-5bbc6dd5db33cb4ea26544784e9cf448bc4cc443260b3712bc43ebb17268cc28R4-R15) [[2]](diffhunk://#diff-9b3f13a0280a67744d39acaf17f186b64dc3bdfc96ca56bd27cf7f76d164138eR4)
* Introduced the `execute` permission middleware in `handlers.go` for new plugin update routes.

These changes collectively enable more granular and up-to-date plugin management for each WordPress site managed by the system.