### PR TITLE
Feat/reminder

### DIFF
--- a/internal/api/task_handlers.go
+++ b/internal/api/task_handlers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/JCO-Digital/jman/internal/db"
 	"github.com/JCO-Digital/jman/internal/models"
+	"github.com/JCO-Digital/jman/internal/tasks"
 )
 
 // ListTasksHandler handles GET /api/tasks
@@ -91,6 +92,10 @@ func CreateTaskHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if task.AssignedTo != nil && *task.AssignedTo != "" {
+		go tasks.NotifyTaskAssigned(&task)
+	}
+
 	WriteJSON(w, http.StatusCreated, task)
 }
 
@@ -164,12 +169,23 @@ func UpdateTaskHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if has("assigned_to") {
 		// Reset LastNotifiedAt if the assignee changes, so the new user gets a reminder
-		if (existing.AssignedTo == nil && updates.AssignedTo != nil) ||
-			(existing.AssignedTo != nil && updates.AssignedTo == nil) ||
-			(existing.AssignedTo != nil && updates.AssignedTo != nil && *existing.AssignedTo != *updates.AssignedTo) {
+		oldAssignee := existing.AssignedTo
+		newAssignee := updates.AssignedTo
+
+		isChanged := (oldAssignee == nil && newAssignee != nil) ||
+			(oldAssignee != nil && newAssignee == nil) ||
+			(oldAssignee != nil && newAssignee != nil && *oldAssignee != *newAssignee)
+
+		if isChanged {
 			existing.LastNotifiedAt = nil
 		}
 		existing.AssignedTo = updates.AssignedTo
+
+		// If a new user is assigned, send a notification
+		if isChanged && newAssignee != nil && *newAssignee != "" {
+			// We use a goroutine to avoid blocking the API response
+			go tasks.NotifyTaskAssigned(existing)
+		}
 	}
 	if has("due_date") {
 		existing.DueDate = updates.DueDate

--- a/internal/api/task_handlers.go
+++ b/internal/api/task_handlers.go
@@ -93,7 +93,8 @@ func CreateTaskHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if task.AssignedTo != nil && *task.AssignedTo != "" {
-		go tasks.NotifyTaskAssigned(&task)
+		taskCopy := task
+		go tasks.NotifyTaskAssigned(&taskCopy)
 	}
 
 	WriteJSON(w, http.StatusCreated, task)
@@ -183,8 +184,9 @@ func UpdateTaskHandler(w http.ResponseWriter, r *http.Request) {
 
 		// If a new user is assigned, send a notification
 		if isChanged && newAssignee != nil && *newAssignee != "" {
-			// We use a goroutine to avoid blocking the API response
-			go tasks.NotifyTaskAssigned(existing)
+			// Pass a copy to the goroutine to avoid data races
+			taskCopy := *existing
+			go tasks.NotifyTaskAssigned(&taskCopy)
 		}
 	}
 	if has("due_date") {

--- a/internal/api/task_handlers.go
+++ b/internal/api/task_handlers.go
@@ -163,6 +163,12 @@ func UpdateTaskHandler(w http.ResponseWriter, r *http.Request) {
 		existing.Priority = updates.Priority
 	}
 	if has("assigned_to") {
+		// Reset LastNotifiedAt if the assignee changes, so the new user gets a reminder
+		if (existing.AssignedTo == nil && updates.AssignedTo != nil) ||
+			(existing.AssignedTo != nil && updates.AssignedTo == nil) ||
+			(existing.AssignedTo != nil && updates.AssignedTo != nil && *existing.AssignedTo != *updates.AssignedTo) {
+			existing.LastNotifiedAt = nil
+		}
 		existing.AssignedTo = updates.AssignedTo
 	}
 	if has("due_date") {

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -229,13 +229,16 @@ func processReminders() error {
 			}
 
 			// Parse reminderTimeStr (expecting HH:mm)
-			var hour, minute int
-			if _, err := fmt.Sscanf(reminderTimeStr, "%d:%d", &hour, &minute); err == nil {
-				todayReminderTime := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
-				if now.Before(todayReminderTime) {
-					// It's before the set time today, skip sending for now
-					continue
-				}
+			reminderTime, err := time.ParseInLocation("15:04", reminderTimeStr, now.Location())
+			if err != nil {
+				// Fallback to default if user setting is invalid
+				reminderTime, _ = time.ParseInLocation("15:04", "10:00", now.Location())
+			}
+
+			todayReminderTime := time.Date(now.Year(), now.Month(), now.Day(), reminderTime.Hour(), reminderTime.Minute(), 0, 0, now.Location())
+			if now.Before(todayReminderTime) {
+				// It's before the set time today, skip sending for now
+				continue
 			}
 
 			sendSlackReminder(&task)

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -216,6 +216,28 @@ func processReminders() error {
 	for _, task := range tasks {
 		if (task.Priority == models.TaskPriorityHigh || task.Priority == models.TaskPriorityMedium) &&
 			task.ReminderDate != nil && task.ReminderDate.Before(now) && task.LastNotifiedAt == nil {
+
+			// Get user's preferred reminder time
+			reminderTimeStr := "10:00"
+			if task.AssignedTo != nil && *task.AssignedTo != "" {
+				setting, err := db.GetSetting(*task.AssignedTo, "slack_reminder_time")
+				if err == nil && setting != nil {
+					if val, ok := setting.Value.(string); ok && val != "" {
+						reminderTimeStr = val
+					}
+				}
+			}
+
+			// Parse reminderTimeStr (expecting HH:mm)
+			var hour, minute int
+			if _, err := fmt.Sscanf(reminderTimeStr, "%d:%d", &hour, &minute); err == nil {
+				todayReminderTime := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
+				if now.Before(todayReminderTime) {
+					// It's before the set time today, skip sending for now
+					continue
+				}
+			}
+
 			sendSlackReminder(&task)
 		}
 	}

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -213,26 +213,39 @@ func processReminders() error {
 	}
 
 	now := time.Now()
+	// Cache for user reminder times to avoid N+1 queries
+	userReminderTimes := make(map[string]time.Time)
+
 	for _, task := range tasks {
 		if (task.Priority == models.TaskPriorityHigh || task.Priority == models.TaskPriorityMedium) &&
 			task.ReminderDate != nil && task.ReminderDate.Before(now) && task.LastNotifiedAt == nil {
 
 			// Get user's preferred reminder time
-			reminderTimeStr := "10:00"
+			assignee := "default"
 			if task.AssignedTo != nil && *task.AssignedTo != "" {
-				setting, err := db.GetSetting(*task.AssignedTo, "slack_reminder_time")
-				if err == nil && setting != nil {
-					if val, ok := setting.Value.(string); ok && val != "" {
-						reminderTimeStr = val
-					}
-				}
+				assignee = *task.AssignedTo
 			}
 
-			// Parse reminderTimeStr (expecting HH:mm)
-			reminderTime, err := time.ParseInLocation("15:04", reminderTimeStr, now.Location())
-			if err != nil {
-				// Fallback to default if user setting is invalid
-				reminderTime, _ = time.ParseInLocation("15:04", "10:00", now.Location())
+			reminderTime, ok := userReminderTimes[assignee]
+			if !ok {
+				reminderTimeStr := "10:00"
+				if assignee != "default" {
+					setting, err := db.GetSetting(assignee, "slack_reminder_time")
+					if err == nil && setting != nil {
+						if val, ok := setting.Value.(string); ok && val != "" {
+							reminderTimeStr = val
+						}
+					}
+				}
+
+				// Parse reminderTimeStr (expecting HH:mm)
+				parsed, err := time.ParseInLocation("15:04", reminderTimeStr, now.Location())
+				if err != nil {
+					// Fallback to default if user setting is invalid
+					parsed, _ = time.ParseInLocation("15:04", "10:00", now.Location())
+				}
+				reminderTime = parsed
+				userReminderTimes[assignee] = reminderTime
 			}
 
 			todayReminderTime := time.Date(now.Year(), now.Month(), now.Day(), reminderTime.Hour(), reminderTime.Minute(), 0, 0, now.Location())

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -244,12 +244,31 @@ func processReminders() error {
 	return nil
 }
 
+// sendSlackReminder sends a reminder notification for a task.
 func sendSlackReminder(task *models.Task) {
 	message := fmt.Sprintf("🔔 *Task Reminder: %s*\nPriority: %s", task.Title, task.Priority)
 	if task.DueDate != nil {
 		message += fmt.Sprintf("\nDue: %s", task.DueDate.Format("2006-01-02"))
 	}
 
+	if sendToAssignee(task, message) {
+		now := time.Now()
+		task.LastNotifiedAt = &now
+		_ = db.SaveTask(task, "system")
+	}
+}
+
+// NotifyTaskAssigned sends a notification to a user when a task is assigned to them.
+func NotifyTaskAssigned(task *models.Task) {
+	message := fmt.Sprintf("📋 *New Task Assigned: %s*\nPriority: %s", task.Title, task.Priority)
+	if task.DueDate != nil {
+		message += fmt.Sprintf("\nDue: %s", task.DueDate.Format("2006-01-02"))
+	}
+
+	sendToAssignee(task, message)
+}
+
+func sendToAssignee(task *models.Task, message string) bool {
 	var sent bool
 	if task.AssignedTo != nil && *task.AssignedTo != "" {
 		setting, err := db.GetSetting(*task.AssignedTo, "slack_id")
@@ -266,12 +285,7 @@ func sendSlackReminder(task *models.Task) {
 			sent = true
 		}
 	}
-
-	if sent {
-		now := time.Now()
-		task.LastNotifiedAt = &now
-		_ = db.SaveTask(task, "system")
-	}
+	return sent
 }
 
 // cleanupOrphanedTasks marks tasks as skipped if they are linked to non-existent entities.


### PR DESCRIPTION
This pull request introduces enhancements to the task assignment and reminder notification system. The main improvements include sending Slack notifications when a task is assigned, resetting notification tracking when the assignee changes, and respecting users' preferred reminder times for Slack notifications.

**Notification Enhancements**

* Added a new notification: When a task is assigned to a user (either on creation or update), a Slack notification is sent to the assignee using the new `NotifyTaskAssigned` function. This is triggered asynchronously to avoid blocking API responses. [[1]](diffhunk://#diff-8a2b92c7f1c94210d8064b05f64af3d718b5535e08c6e33b7a9107fb3902ca7fR12) [[2]](diffhunk://#diff-8a2b92c7f1c94210d8064b05f64af3d718b5535e08c6e33b7a9107fb3902ca7fR95-R98) [[3]](diffhunk://#diff-8a2b92c7f1c94210d8064b05f64af3d718b5535e08c6e33b7a9107fb3902ca7fR171-R188) [[4]](diffhunk://#diff-c4fe907372f3793062f1037f974275931e09f6300be678389aa017cf486ee83bR219-R271)

* When updating a task's assignee, the `LastNotifiedAt` field is reset if the assignee changes, ensuring the new assignee receives reminders.

**Reminder Scheduling Improvements**

* The reminder scheduler now checks each user's preferred Slack reminder time (from the `slack_reminder_time` setting) and sends reminders only after that time has passed each day. This prevents reminders from being sent too early for each user.

**Code Organization and Reuse**

* Refactored notification logic: Extracted common logic for sending Slack messages to a new `sendToAssignee` helper, and clarified responsibilities between `sendSlackReminder` and `NotifyTaskAssigned`. [[1]](diffhunk://#diff-c4fe907372f3793062f1037f974275931e09f6300be678389aa017cf486ee83bR219-R271) [[2]](diffhunk://#diff-c4fe907372f3793062f1037f974275931e09f6300be678389aa017cf486ee83bL247-R288)