### PR TITLE
fix(api): improve error handling and response consistency for plugin

### DIFF
--- a/docs/API_SPECS.md
+++ b/docs/API_SPECS.md
@@ -579,11 +579,12 @@ If the plugin is already up to date, `status` will be `"Up to date"` and version
 	"name": "akismet",
 	"old_version": "5.0.0",
 	"new_version": "5.0.0",
-	"status": "failed"
+	"status": "failed",
+	"error": "Error message"
 }
 ```
 
-If the update fails, `status` will be `"failed"` and versions will reflect the state before the attempt.
+If the update fails, `status` will be `"failed"`, versions will reflect the state before the attempt, and the `error` field will contain a description of the failure.
 
 ---
 

--- a/docs/API_SPECS.md
+++ b/docs/API_SPECS.md
@@ -570,7 +570,20 @@ Updates one plugin on the site. The plugin cache is refreshed in the background 
 }
 ```
 
-Returns an empty array if the plugin had no update available. The `status` field reflects the WP-CLI result (e.g. `"Updated"`).
+If the plugin is already up to date, `status` will be `"Up to date"` and versions will be identical.
+
+**Response (500 Internal Server Error)**
+
+```json
+{
+	"name": "akismet",
+	"old_version": "5.0.0",
+	"new_version": "5.0.0",
+	"status": "failed"
+}
+```
+
+If the update fails, `status` will be `"failed"` and versions will reflect the state before the attempt.
 
 ---
 

--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/JCO-Digital/jman/internal/cache"
 	"github.com/JCO-Digital/jman/internal/db"
@@ -238,23 +237,50 @@ func SitePluginUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := wpcli.UpdatePlugin(*site, []string{body.Plugin})
-	if err != nil {
-		msg := err.Error()
-		if msg == "" || msg == "failed to update plugin" || strings.Contains(msg, "(stderr:") {
-			WriteError(w, http.StatusInternalServerError, "Failed to update plugin")
-		} else {
-			WriteError(w, http.StatusInternalServerError, msg)
+	// Try to get current version from cache for fallback
+	currentVersion := ""
+	if plugins, err := db.GetSitePlugins(site.ID); err == nil {
+		for _, p := range plugins {
+			if p.Name == body.Plugin {
+				currentVersion = p.Version
+				break
+			}
 		}
+	}
+
+	results, err := wpcli.UpdatePlugin(*site, []string{body.Plugin})
+
+	var response wpcli.UpdateResult
+	response.Name = body.Plugin
+
+	if err != nil {
+		response.Status = "failed"
+		response.OldVersion = currentVersion
+		response.NewVersion = currentVersion
+		WriteJSON(w, http.StatusInternalServerError, response)
 		return
 	}
 
 	if len(results) == 0 {
-		WriteJSON(w, http.StatusOK, []wpcli.UpdateResult{})
+		response.Status = "Up to date"
+		response.OldVersion = currentVersion
+		response.NewVersion = currentVersion
+		WriteJSON(w, http.StatusOK, response)
 		return
 	}
 
-	result := results[0]
+	response = results[0]
+
+	// Normalize status to "failed" if it's not "Updated" and ensure versions are same on failure.
+	if response.Status != "Updated" {
+		response.Status = "failed"
+		if response.OldVersion == "" {
+			response.OldVersion = currentVersion
+		}
+		response.NewVersion = response.OldVersion
+		WriteJSON(w, http.StatusInternalServerError, response)
+		return
+	}
 
 	// Refresh the full plugin list for this site so all versions and
 	// update_available flags reflect the post-update state.
@@ -264,7 +290,7 @@ func SitePluginUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	WriteJSON(w, http.StatusOK, result)
+	WriteJSON(w, http.StatusOK, response)
 }
 
 func getSiteByID(id int) (*models.CliSite, error) {

--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -257,6 +257,7 @@ func SitePluginUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		response.Status = "failed"
 		response.OldVersion = currentVersion
 		response.NewVersion = currentVersion
+		response.Error = err.Error()
 		WriteJSON(w, http.StatusInternalServerError, response)
 		return
 	}
@@ -278,6 +279,7 @@ func SitePluginUpdateHandler(w http.ResponseWriter, r *http.Request) {
 			response.OldVersion = currentVersion
 		}
 		response.NewVersion = response.OldVersion
+		response.Error = "Plugin update failed"
 		WriteJSON(w, http.StatusInternalServerError, response)
 		return
 	}

--- a/internal/wpcli/plugins.go
+++ b/internal/wpcli/plugins.go
@@ -87,6 +87,7 @@ type UpdateResult struct {
 	OldVersion string `json:"old_version"`
 	NewVersion string `json:"new_version"`
 	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
 }
 
 // UpdatePlugin updates one or more plugins.


### PR DESCRIPTION
updates

Standardize the response format for plugin updates to include consistent versioning and status
reporting, even when updates fail or plugins are already up to date. Update the API documentation to
reflect these changes.